### PR TITLE
Use sqlglot[rs]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ bench-rust:
 
 # Run Python sqlglot benchmarks (JSON output)
 bench-python:
-	@uv run --with sqlglot python3 tools/bench-compare/bench_sqlglot.py
+	@uv run --with sqlglot[rs] python3 tools/bench-compare/bench_sqlglot.py
 
 # =============================================================================
 # Build

--- a/tools/bench-compare/bench_sqlglot.py
+++ b/tools/bench-compare/bench_sqlglot.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Benchmark sqlglot operations and output JSON for comparison with polyglot-sql.
 
-Run with: uv run --with sqlglot python3 tools/bench-compare/bench_sqlglot.py
+Run with: uv run --with sqlglot[rs] python3 tools/bench-compare/bench_sqlglot.py
 """
 
 import json

--- a/tools/bench-compare/compare.py
+++ b/tools/bench-compare/compare.py
@@ -32,7 +32,7 @@ def run_rust_bench():
 def run_python_bench():
     print("Running sqlglot benchmarks...", file=sys.stderr)
     result = subprocess.run(
-        ["uv", "run", "--with", "sqlglot", "python3",
+        ["uv", "run", "--with", "sqlglot[rs]", "python3",
          os.path.join(PROJECT_ROOT, "tools", "bench-compare", "bench_sqlglot.py")],
         capture_output=True,
         text=True,


### PR DESCRIPTION
Hi!

First of all, really excited to see this project and great work! I'm a big fan and user of `sqlglot` so any speedup in the world of SQL parsing is music to my ears. Looking forward to potential python bindings.

When trying out the benchmark I noticed you did not use the rust tokenizer for sqlglot (`sqlglot[rs]`), I would suggest changing to those to give as fair comparison as possible. The difference is (geometric mean) `~8x` faster to `~7x` faster which is still really exciting.
```py
["uv", "run", "--with", "sqlglot", "python3", os.path.join(PROJECT_ROOT, "tools", "bench-compare", "bench_sqlglot.py")]
```
To:
```py
["uv", "run", "--with", "sqlglot[rs]", "python3", os.path.join(PROJECT_ROOT, "tools", "bench-compare", "bench_sqlglot.py")]
```
[link](https://github.com/tobilg/polyglot/blob/main/tools/bench-compare/compare.py#L35-L36)

Could not find any contributing guidelines, so let me know if you'd prefer a different approach, happy to adjust.

Thanks again for building this!