### PR TITLE
Fix return types for FLOOR, CEIL, and DATE_FORMAT in annotate_types

### DIFF
--- a/crates/polyglot-sql/src/optimizer/annotate_types.rs
+++ b/crates/polyglot-sql/src/optimizer/annotate_types.rs
@@ -276,6 +276,20 @@ impl<'a> TypeAnnotator<'a> {
                 integer_spelling: false,
             },
         );
+        self.function_return_types.insert(
+            "DATE_FORMAT".to_string(),
+            DataType::VarChar {
+                length: None,
+                parenthesized_length: false,
+            },
+        );
+        self.function_return_types.insert(
+            "FORMAT_DATE".to_string(),
+            DataType::VarChar {
+                length: None,
+                parenthesized_length: false,
+            },
+        );
 
         // Math functions
         self.function_return_types.insert(
@@ -292,12 +306,27 @@ impl<'a> TypeAnnotator<'a> {
                 scale: None,
             },
         );
-        self.function_return_types
-            .insert("FLOOR".to_string(), DataType::BigInt { length: None });
-        self.function_return_types
-            .insert("CEIL".to_string(), DataType::BigInt { length: None });
-        self.function_return_types
-            .insert("CEILING".to_string(), DataType::BigInt { length: None });
+        self.function_return_types.insert(
+            "FLOOR".to_string(),
+            DataType::Double {
+                precision: None,
+                scale: None,
+            },
+        );
+        self.function_return_types.insert(
+            "CEIL".to_string(),
+            DataType::Double {
+                precision: None,
+                scale: None,
+            },
+        );
+        self.function_return_types.insert(
+            "CEILING".to_string(),
+            DataType::Double {
+                precision: None,
+                scale: None,
+            },
+        );
         self.function_return_types.insert(
             "SQRT".to_string(),
             DataType::Double {
@@ -544,7 +573,9 @@ impl<'a> TypeAnnotator<'a> {
             | Expression::Lpad(_)
             | Expression::Rpad(_)
             | Expression::ConcatWs(_)
-            | Expression::Overlay(_) => Some(DataType::VarChar {
+            | Expression::Overlay(_)
+            | Expression::DateFormat(_)
+            | Expression::FormatDate(_) => Some(DataType::VarChar {
                 length: None,
                 parenthesized_length: false,
             }),
@@ -568,9 +599,11 @@ impl<'a> TypeAnnotator<'a> {
                 precision: None,
                 scale: None,
             }),
-            Expression::Floor(_) | Expression::Ceil(_) | Expression::Sign(_) => {
-                Some(DataType::BigInt { length: None })
-            }
+            Expression::Floor(_) | Expression::Ceil(_) => Some(DataType::Double {
+                precision: None,
+                scale: None,
+            }),
+            Expression::Sign(_) => Some(DataType::BigInt { length: None }),
 
             // Greatest/Least - coerce argument types
             Expression::Greatest(v) | Expression::Least(v) => self.coerce_arg_types(&v.expressions),


### PR DESCRIPTION
## Summary
- **FLOOR/CEIL/CEILING**: Changed inferred return type from `BigInt` to `Double` to align with sqlglot behavior. Updated both the function return types map and the expression match handlers.
- **DATE_FORMAT/FORMAT_DATE**: Added `VarChar` return type annotation. These were previously unhandled, returning unknown type. Updated both the function map and expression match handlers.
- **SIGN**: Preserved existing `BigInt` return type (separated from the FLOOR/CEIL match arm).

This fixes #49 

## Test plan
- [x] All 19 existing `annotate_types` unit tests pass
- [ ] Verify FLOOR/CEIL return `Double` with float input via `annotate_types`
- [ ] Verify DATE_FORMAT returns `VarChar` via `annotate_types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)