### PR TITLE
fix: resolve nested CTE SELECT * in column lineage

### DIFF
--- a/crates/polyglot-sql/src/lineage.rs
+++ b/crates/polyglot-sql/src/lineage.rs
@@ -3666,6 +3666,8 @@ LEFT JOIN import_orders AS o ON u.id = o.user_id"#;
             "Known bug: quoted CTE case mismatch should NOT resolve, but currently does. \
              If this fails, the bug may be fixed — update to assert source_name != \"MyCte\""
         );
+    }
+
     // --- Comment handling tests (ported from sqlglot test_lineage.py) ---
 
     /// sqlglot: test_node_name_doesnt_contain_comment


### PR DESCRIPTION
## Summary

- Expand CTE-based `SELECT *` in `lineage()` so that columns can be traced through CTEs without requiring external schema metadata
- Handle nested CTEs (e.g., `cte2 AS (SELECT * FROM cte1)`) by walking CTE definitions in order and propagating resolved column lists, replacing the previous `qualify_columns`-based approach which processed each SELECT independently
- Support edge cases: UNION CTE bodies (left branch), explicit CTE column lists (`cte(a, b) AS (...)`), qualified stars (`cte.*`), recursive CTE skip, unknown table graceful fallback
- **Schema-aware expansion:** Pass optional schema to `expand_cte_stars` so that stars from external tables (not CTEs) can also be resolved via schema column lookup
- **Table-qualified star expansion:** Expanded columns from `SELECT *` now carry their source table qualifier, enabling proper lineage tracing through nested CTE chains with JOINs
- **Sibling CTE resolution:** `resolve_qualified_column` now checks ancestor CTE scopes for sibling CTEs in parent WITH clauses, fixing lineage resolution failures when a CTE references another CTE defined in the same WITH block
- **Recursion depth limit:** Add `MAX_LINEAGE_DEPTH` (64) counter to `to_node_inner` and all recursive callers to prevent stack overflow on circular or deeply nested CTE chains. `get_leftmost_select_mut` also converted to iterative loop with the same depth guard.
- **SQL identifier case semantics for CTE name matching:** Added `normalize_cte_name()` helper that lowercases unquoted identifiers (case-insensitive per SQL spec) and preserves quoted identifiers as-is (case-sensitive), matching sqlglot `normalize_identifiers` behavior. Introduced `SourceName` struct to carry normalization info through star expansion.
- Make `expand_cte_stars` public as a building block for consumers who need to pre-process CTE star expansion independently (e.g., with schema information) before running lineage analysis

### Known limitations

The star expansion path (`expand_cte_stars`) correctly handles quoted vs unquoted CTE name matching, but the broader scope/lineage resolution paths (`add_table_to_scope` in scope.rs, `resolve_qualified_column` in lineage.rs) still use `eq_ignore_ascii_case` without respecting the `quoted` flag on identifiers. Known-bug tests document this for future work.

## Test plan

- [x] Single CTE, nested (2-level, 3-level), UNION body, explicit column lists, qualified stars
- [x] Schema-based expansion: external tables, 3-part qualified names, nested CTEs with JOINs
- [x] Backward compatibility without schema
- [x] CTE alias resolution with and without schema
- [x] Quoted/unquoted CTE case sensitivity: case-insensitive unquoted, case-preserved quoted, case-mismatch no expansion, mixed chains
- [x] Known-bug tests for scope/lineage path identifier case sensitivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)