### PR TITLE
feat(fabric): map PostgreSQL BPCHAR type to CHAR for Fabric/TSQL

### DIFF
--- a/crates/polyglot-sql/src/dialects/fabric.rs
+++ b/crates/polyglot-sql/src/dialects/fabric.rs
@@ -63,7 +63,14 @@ impl DialectImpl for FabricDialect {
                     }
                     _ => {}
                 }
-                // Also transform column data types through Fabric's type mappings
+                // Also transform column data types through Fabric's type mappings.
+                // Apply TSQL normalisation first (e.g. BPCHAR → Char), then Fabric-specific.
+                let tsql = TSQLDialect;
+                if let Ok(Expression::DataType(tsql_dt)) =
+                    tsql.transform_data_type(col.data_type.clone())
+                {
+                    col.data_type = tsql_dt;
+                }
                 if let Expression::DataType(new_dt) =
                     self.transform_fabric_data_type(col.data_type.clone())?
                 {
@@ -361,7 +368,8 @@ impl FabricDialect {
                 let upper = name.to_uppercase();
 
                 // Parse out precision and scale if present: "TYPENAME(n)" or "TYPENAME(n, m)"
-                let (base_name, precision, scale) = Self::parse_type_precision_and_scale(&upper);
+                let (base_name, precision, scale) =
+                    TSQLDialect::parse_type_precision_and_scale(&upper);
 
                 match base_name.as_str() {
                     // DATETIME -> DATETIME2(6)
@@ -516,26 +524,6 @@ impl FabricDialect {
             Some(p) if p > max => max,
             Some(p) => p,
             None => max, // Default to max if not specified
-        }
-    }
-
-    /// Parse type name and optional precision/scale from strings like "DATETIME2(7)" or "NUMERIC(10, 2)"
-    fn parse_type_precision_and_scale(name: &str) -> (String, Option<u32>, Option<u32>) {
-        if let Some(paren_pos) = name.find('(') {
-            let base = name[..paren_pos].to_string();
-            let rest = &name[paren_pos + 1..];
-            if let Some(close_pos) = rest.find(')') {
-                let args = &rest[..close_pos];
-                let parts: Vec<&str> = args.split(',').map(|s| s.trim()).collect();
-
-                let precision = parts.first().and_then(|s| s.parse::<u32>().ok());
-                let scale = parts.get(1).and_then(|s| s.parse::<u32>().ok());
-
-                return (base, precision, scale);
-            }
-            (base, None, None)
-        } else {
-            (name.to_string(), None, None)
         }
     }
 }

--- a/crates/polyglot-sql/src/dialects/tsql.rs
+++ b/crates/polyglot-sql/src/dialects/tsql.rs
@@ -91,6 +91,18 @@ impl DialectImpl for TSQLDialect {
     }
 
     fn transform_expr(&self, expr: Expression) -> Result<Expression> {
+        // Transform column data types in DDL (transform_recursive skips them by design).
+        if let Expression::CreateTable(mut ct) = expr {
+            for col in &mut ct.columns {
+                if let Ok(Expression::DataType(new_dt)) =
+                    self.transform_data_type(col.data_type.clone())
+                {
+                    col.data_type = new_dt;
+                }
+            }
+            return Ok(Expression::CreateTable(ct));
+        }
+
         match expr {
             // ===== SELECT a = 1 → SELECT 1 AS a =====
             // In T-SQL, `SELECT a = expr` is equivalent to `SELECT expr AS a`
@@ -637,7 +649,7 @@ impl DialectImpl for TSQLDialect {
 
 impl TSQLDialect {
     /// Transform data types according to T-SQL TYPE_MAPPING
-    fn transform_data_type(&self, dt: crate::expressions::DataType) -> Result<Expression> {
+    pub(super) fn transform_data_type(&self, dt: crate::expressions::DataType) -> Result<Expression> {
         use crate::expressions::DataType;
         let transformed = match dt {
             // BOOLEAN -> BIT
@@ -669,10 +681,47 @@ impl TSQLDialect {
             DataType::Uuid => DataType::Custom {
                 name: "UNIQUEIDENTIFIER".to_string(),
             },
+            // Normalise custom type names that have PostgreSQL aliases
+            DataType::Custom { ref name } => {
+                let upper = name.trim().to_uppercase();
+                let (base_name, precision, _scale) =
+                    Self::parse_type_precision_and_scale(&upper);
+                match base_name.as_str() {
+                    // BPCHAR is PostgreSQL's blank-padded CHAR alias — map to CHAR
+                    "BPCHAR" => {
+                        if let Some(len) = precision {
+                            DataType::Char { length: Some(len) }
+                        } else {
+                            DataType::Char { length: None }
+                        }
+                    }
+                    _ => dt,
+                }
+            }
             // Keep all other types as-is
             other => other,
         };
         Ok(Expression::DataType(transformed))
+    }
+
+    /// Parse a type name that may embed precision/scale: `"TYPENAME(n, m)"` → `("TYPENAME", Some(n), Some(m))`.
+    pub(super) fn parse_type_precision_and_scale(
+        name: &str,
+    ) -> (String, Option<u32>, Option<u32>) {
+        if let Some(paren_pos) = name.find('(') {
+            let base = name[..paren_pos].to_string();
+            let rest = &name[paren_pos + 1..];
+            if let Some(close_pos) = rest.find(')') {
+                let args = &rest[..close_pos];
+                let parts: Vec<&str> = args.split(',').map(|s| s.trim()).collect();
+                let precision = parts.first().and_then(|s| s.parse::<u32>().ok());
+                let scale = parts.get(1).and_then(|s| s.parse::<u32>().ok());
+                return (base, precision, scale);
+            }
+            (base, None, None)
+        } else {
+            (name.to_string(), None, None)
+        }
     }
 
     fn transform_function(&self, f: Function) -> Result<Expression> {

--- a/crates/polyglot-sql/src/parser.rs
+++ b/crates/polyglot-sql/src/parser.rs
@@ -39890,7 +39890,7 @@ impl Parser {
                 };
                 DataType::Double { precision, scale }
             }
-            "CHARACTER" | "CHAR" | "NCHAR" => {
+            "BPCHAR" | "CHARACTER" | "CHAR" | "NCHAR" => {
                 // Handle CHARACTER VARYING / CHAR VARYING
                 if self.match_identifier("VARYING") {
                     let length = if self.match_token(TokenType::LParen) {

--- a/crates/polyglot-sql/tests/fabric_regression.rs
+++ b/crates/polyglot-sql/tests/fabric_regression.rs
@@ -1,0 +1,73 @@
+//! Regression tests for PostgreSQL → Fabric transpilation.
+
+use polyglot_sql::{transpile, DialectType};
+
+fn pg_to_fabric(sql: &str) -> String {
+    transpile(sql, DialectType::PostgreSQL, DialectType::Fabric)
+        .unwrap_or_else(|e| panic!("transpile failed for {sql:?}: {e}"))
+        .into_iter()
+        .next()
+        .expect("expected at least one statement")
+}
+
+// ---------------------------------------------------------------------------
+// BPCHAR → CHAR normalisation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bpchar_cast_no_length_maps_to_char() {
+    let out = pg_to_fabric("SELECT CAST(x AS BPCHAR)");
+    assert!(
+        out.contains("CAST(x AS CHAR)") || out.contains("CAST([x] AS CHAR)"),
+        "expected CAST(x AS CHAR), got: {out}"
+    );
+}
+
+#[test]
+fn bpchar_cast_with_length_maps_to_char() {
+    let out = pg_to_fabric("SELECT CAST(x AS BPCHAR(3))");
+    assert!(
+        out.contains("CAST(x AS CHAR(3))") || out.contains("CAST([x] AS CHAR(3))"),
+        "expected CAST(x AS CHAR(3)), got: {out}"
+    );
+}
+
+#[test]
+fn bpchar_double_colon_no_length_maps_to_char() {
+    let out = pg_to_fabric("SELECT x::bpchar");
+    assert!(
+        out.to_uppercase().contains("AS CHAR"),
+        "expected AS CHAR in output, got: {out}"
+    );
+}
+
+#[test]
+fn bpchar_double_colon_with_length_maps_to_char() {
+    let out = pg_to_fabric("SELECT x::bpchar(3)");
+    assert!(
+        out.to_uppercase().contains("AS CHAR(3)"),
+        "expected AS CHAR(3) in output, got: {out}"
+    );
+}
+
+#[test]
+fn bpchar_ddl_column_no_length_maps_to_char() {
+    let out = pg_to_fabric("CREATE TABLE t (x BPCHAR)");
+    assert!(
+        out.to_uppercase().contains("CHAR"),
+        "expected CHAR type in DDL, got: {out}"
+    );
+    assert!(
+        !out.to_uppercase().contains("BPCHAR"),
+        "BPCHAR should not appear in output, got: {out}"
+    );
+}
+
+#[test]
+fn bpchar_ddl_column_with_length_maps_to_char() {
+    let out = pg_to_fabric("CREATE TABLE t (x BPCHAR(3))");
+    assert!(
+        out.to_uppercase().contains("CHAR(3)"),
+        "expected CHAR(3) in DDL, got: {out}"
+    );
+}

--- a/crates/polyglot-sql/tests/tsql_regression.rs
+++ b/crates/polyglot-sql/tests/tsql_regression.rs
@@ -1,0 +1,73 @@
+//! Regression tests for PostgreSQL → T-SQL transpilation.
+
+use polyglot_sql::{transpile, DialectType};
+
+fn pg_to_tsql(sql: &str) -> String {
+    transpile(sql, DialectType::PostgreSQL, DialectType::TSQL)
+        .unwrap_or_else(|e| panic!("transpile failed for {sql:?}: {e}"))
+        .into_iter()
+        .next()
+        .expect("expected at least one statement")
+}
+
+// ---------------------------------------------------------------------------
+// BPCHAR → CHAR normalisation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bpchar_cast_no_length_maps_to_char() {
+    let out = pg_to_tsql("SELECT CAST(x AS BPCHAR)");
+    assert!(
+        out.contains("CAST(x AS CHAR)") || out.contains("CAST([x] AS CHAR)"),
+        "expected CAST(x AS CHAR), got: {out}"
+    );
+}
+
+#[test]
+fn bpchar_cast_with_length_maps_to_char() {
+    let out = pg_to_tsql("SELECT CAST(x AS BPCHAR(3))");
+    assert!(
+        out.contains("CAST(x AS CHAR(3))") || out.contains("CAST([x] AS CHAR(3))"),
+        "expected CAST(x AS CHAR(3)), got: {out}"
+    );
+}
+
+#[test]
+fn bpchar_double_colon_no_length_maps_to_char() {
+    let out = pg_to_tsql("SELECT x::bpchar");
+    assert!(
+        out.to_uppercase().contains("AS CHAR"),
+        "expected AS CHAR in output, got: {out}"
+    );
+}
+
+#[test]
+fn bpchar_double_colon_with_length_maps_to_char() {
+    let out = pg_to_tsql("SELECT x::bpchar(3)");
+    assert!(
+        out.to_uppercase().contains("AS CHAR(3)"),
+        "expected AS CHAR(3) in output, got: {out}"
+    );
+}
+
+#[test]
+fn bpchar_ddl_column_no_length_maps_to_char() {
+    let out = pg_to_tsql("CREATE TABLE t (x BPCHAR)");
+    assert!(
+        out.to_uppercase().contains("CHAR"),
+        "expected CHAR type in DDL, got: {out}"
+    );
+    assert!(
+        !out.to_uppercase().contains("BPCHAR"),
+        "BPCHAR should not appear in output, got: {out}"
+    );
+}
+
+#[test]
+fn bpchar_ddl_column_with_length_maps_to_char() {
+    let out = pg_to_tsql("CREATE TABLE t (x BPCHAR(3))");
+    assert!(
+        out.to_uppercase().contains("CHAR(3)"),
+        "expected CHAR(3) in DDL, got: {out}"
+    );
+}


### PR DESCRIPTION
PostgreSQL's BPCHAR ("blank-padded char") is an alias for CHAR.