### PR TITLE
fix(playground): Fix JsonTree scroll overflow

### DIFF
--- a/packages/playground/src/components/shared/json-tree.tsx
+++ b/packages/playground/src/components/shared/json-tree.tsx
@@ -156,7 +156,7 @@ interface JsonTreeProps {
 export function JsonTree({ data, defaultExpanded = 2, className }: JsonTreeProps) {
   return (
     <div className={cn("rounded-md border border-code-border bg-code-bg flex flex-col", className)}>
-      <ScrollArea className="flex-1">
+      <ScrollArea className="flex-1 h-full">
         <div className="p-3 text-xs font-mono text-code-text">
           <JsonNode value={data} depth={0} defaultExpanded={defaultExpanded} />
         </div>


### PR DESCRIPTION
# Description

Fixes #239

## Summary

Add `h-full` to the `ScrollArea` in `JsonTree` so JSON panels get a bounded height and scroll when content overflows. Affects AST Explorer and Lineage (JSON view).

## Verification

**AST Explorer**

[ast-json-tree-scroll-fixed.webm](https://github.com/user-attachments/assets/0570ec28-e414-4962-a5a5-8bdd20b150fa)

**Lineage (JSON view)**

[lineage-json-tree-scroll-fixed.webm](https://github.com/user-attachments/assets/02eddf40-0840-409e-91c5-7d7fbb823754)
