### PR TITLE
fix(transform): recurse into window value-function arguments in transform_recursive

### DIFF
--- a/crates/polyglot-sql/src/dialects/mod.rs
+++ b/crates/polyglot-sql/src/dialects/mod.rs
@@ -3286,6 +3286,29 @@ where
             Expression::ArrayPosition(f)
         }
 
+        // LEAD/LAG (LeadLagFunc): recurse into the value argument, offset, and default so
+        // transforms (e.g. column qualification) reach columns inside `LAG(col) OVER (...)`.
+        Expression::Lag(mut f) => {
+            f.this = transform_recursive(f.this, transform_fn)?;
+            if let Some(offset) = f.offset.take() {
+                f.offset = Some(transform_recursive(offset, transform_fn)?);
+            }
+            if let Some(default) = f.default.take() {
+                f.default = Some(transform_recursive(default, transform_fn)?);
+            }
+            Expression::Lag(f)
+        }
+        Expression::Lead(mut f) => {
+            f.this = transform_recursive(f.this, transform_fn)?;
+            if let Some(offset) = f.offset.take() {
+                f.offset = Some(transform_recursive(offset, transform_fn)?);
+            }
+            if let Some(default) = f.default.take() {
+                f.default = Some(transform_recursive(default, transform_fn)?);
+            }
+            Expression::Lead(f)
+        }
+
         // Pass through leaf nodes unchanged
         other => other,
     };

--- a/crates/polyglot-sql/src/dialects/mod.rs
+++ b/crates/polyglot-sql/src/dialects/mod.rs
@@ -3308,6 +3308,41 @@ where
             }
             Expression::Lead(f)
         }
+        // FIRST_VALUE/LAST_VALUE (ValueFunc): recurse into the value argument and any in-function
+        // ORDER BY so transforms reach their columns.
+        Expression::FirstValue(mut f) => {
+            f.this = transform_recursive(f.this, transform_fn)?;
+            for ord in &mut f.order_by {
+                ord.this = transform_recursive(
+                    std::mem::replace(&mut ord.this, Expression::Null(crate::expressions::Null)),
+                    transform_fn,
+                )?;
+            }
+            Expression::FirstValue(f)
+        }
+        Expression::LastValue(mut f) => {
+            f.this = transform_recursive(f.this, transform_fn)?;
+            for ord in &mut f.order_by {
+                ord.this = transform_recursive(
+                    std::mem::replace(&mut ord.this, Expression::Null(crate::expressions::Null)),
+                    transform_fn,
+                )?;
+            }
+            Expression::LastValue(f)
+        }
+        // NTH_VALUE (NthValueFunc): recurse into the value argument and the offset.
+        Expression::NthValue(mut f) => {
+            f.this = transform_recursive(f.this, transform_fn)?;
+            f.offset = transform_recursive(f.offset, transform_fn)?;
+            Expression::NthValue(f)
+        }
+        // NTILE (NTileFunc): recurse into the bucket-count argument.
+        Expression::NTile(mut f) => {
+            if let Some(n) = f.num_buckets.take() {
+                f.num_buckets = Some(transform_recursive(n, transform_fn)?);
+            }
+            Expression::NTile(f)
+        }
 
         // Pass through leaf nodes unchanged
         other => other,

--- a/crates/polyglot-sql/src/optimizer/qualify_columns.rs
+++ b/crates/polyglot-sql/src/optimizer/qualify_columns.rs
@@ -3436,6 +3436,46 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_qualify_columns_inside_lag_lead_window() {
+        // Regression: transform_recursive must recurse into LEAD/LAG arguments
+        // (value, offset, default) so qualify_columns reaches columns inside
+        // `LAG(col) OVER (...)` / `LEAD(col, n, fallback) OVER (...)`. Before the
+        // fix the value column was left unqualified.
+        let expr = parse(
+            "SELECT LAG(val) OVER (PARTITION BY grp ORDER BY id) AS prev, \
+             LEAD(val, 1, fallback) OVER (ORDER BY id) AS nxt \
+             FROM t1",
+        );
+
+        let mut schema = MappingSchema::new();
+        schema
+            .add_table(
+                "t1",
+                &[
+                    ("id".to_string(), DataType::BigInt { length: None }),
+                    ("grp".to_string(), DataType::BigInt { length: None }),
+                    ("val".to_string(), DataType::BigInt { length: None }),
+                    ("fallback".to_string(), DataType::BigInt { length: None }),
+                ],
+                None,
+            )
+            .expect("schema setup");
+
+        let result =
+            qualify_columns(expr, &schema, &QualifyColumnsOptions::new()).expect("qualify");
+        let sql = gen(&result);
+
+        assert!(
+            sql.contains("t1.val"),
+            "value column inside LAG/LEAD should be qualified: {sql}"
+        );
+        assert!(
+            sql.contains("t1.fallback"),
+            "default column inside LEAD should be qualified: {sql}"
+        );
+    }
+
     // ======================================================================
     // quote_identifiers tests
     // ======================================================================


### PR DESCRIPTION
## Problem

`transform_recursive` (the driver behind AST transforms such as `qualify_columns`) did not
recurse into the window **value-function** family. Their argument sub-expressions hit the
`other => other` catch-all, so transforms never reached the columns inside them. Concretely,
`qualify_columns` binds the column inside `SUM(a) OVER (...)` (an `AggFunc`) but **not** inside
`LAG(a) OVER (...)`, `FIRST_VALUE(a) OVER (...)`, `NTH_VALUE(a, 2) OVER (...)`, etc., leaving
those columns unqualified — which breaks any downstream consumer that resolves columns
(type inference, lineage).

## Fix

Add recursion arms before the catch-all for the whole family:

- `LeadLagFunc` (LEAD / LAG) — value arg + default.
- `ValueFunc` (FIRST_VALUE / LAST_VALUE) — value arg **and** the in-function `ORDER BY`.
- `NthValueFunc` (NTH_VALUE) — value arg + offset.
- `NTileFunc` (NTILE) — bucket-count arg.

Each recurses into its child expressions exactly like the existing `AggFunc` arm, so
`qualify_columns` (and every other transform) now binds columns inside them.

No behaviour change for inputs that don't use these functions.