### PR TITLE
Fix CREATE VIEW parsing when COMMENT precedes SECURITY (Trino/Presto)

### DIFF
--- a/crates/polyglot-sql/src/parser.rs
+++ b/crates/polyglot-sql/src/parser.rs
@@ -17980,55 +17980,76 @@ impl Parser {
             row_access_policy = self.parse_snowflake_row_access_policy_clause();
         }
 
-        // Presto/Trino/StarRocks: SECURITY DEFINER/INVOKER/NONE (after view name, before AS)
-        // MySQL also allows SQL SECURITY DEFINER/INVOKER after the view name
-        // This differs from MySQL's SQL SECURITY which can also come before VIEW keyword
-        let (security, security_sql_style, security_after_name) = if security.is_some() {
-            // MySQL-style SQL SECURITY was parsed before VIEW keyword
-            (security, true, false)
-        } else if self.check_identifier("SQL")
-            && self.current + 1 < self.tokens.len()
-            && self.tokens[self.current + 1]
-                .text
-                .eq_ignore_ascii_case("SECURITY")
-        {
-            // SQL SECURITY after view name
-            self.skip(); // consume SQL
-            self.skip(); // consume SECURITY
-            let sec = if self.match_identifier("DEFINER") {
-                Some(FunctionSecurity::Definer)
-            } else if self.match_identifier("INVOKER") {
-                Some(FunctionSecurity::Invoker)
-            } else if self.match_identifier("NONE") {
-                Some(FunctionSecurity::None)
-            } else {
-                None
-            };
-            (sec, true, true)
-        } else if self.match_identifier("SECURITY") {
-            // Presto-style SECURITY after view name
-            let sec = if self.match_identifier("DEFINER") {
-                Some(FunctionSecurity::Definer)
-            } else if self.match_identifier("INVOKER") {
-                Some(FunctionSecurity::Invoker)
-            } else if self.match_identifier("NONE") {
-                Some(FunctionSecurity::None)
-            } else {
-                None
-            };
-            (sec, false, false)
-        } else {
-            (None, true, false)
-        };
+        // View SECURITY and COMMENT clauses, parsed in either order.
+        //
+        // Trino/Presto document the canonical ordering as COMMENT before SECURITY:
+        //     CREATE VIEW v COMMENT 'c' SECURITY DEFINER AS ...
+        // while MySQL/other tooling emit SECURITY before COMMENT:
+        //     CREATE VIEW v SECURITY DEFINER COMMENT 'c' AS ...
+        // Parsing them in a loop accepts both orderings (previously SECURITY was
+        // consumed first, so the canonical Trino form failed to parse once a
+        // COMMENT preceded SECURITY). Snowflake's `COMMENT = 'text'` and MySQL's
+        // `SQL SECURITY` (which may already have been parsed before the VIEW
+        // keyword) are handled here too.
+        let mut security = security;
+        // `security_sql_style` / `security_after_name` only influence generation
+        // when `security` is Some; the initial values preserve the previous
+        // defaults for the "no SECURITY clause after the name" case.
+        let mut security_sql_style = true;
+        let mut security_after_name = false;
+        let mut view_comment: Option<String> = None;
 
-        // Snowflake: COMMENT = 'text'
-        let view_comment = if self.match_token(TokenType::Comment) {
-            // Match = or skip if not present (some dialects use COMMENT='text')
-            let _ = self.match_token(TokenType::Eq);
-            Some(self.expect_string()?)
-        } else {
-            None
-        };
+        loop {
+            // SECURITY / SQL SECURITY DEFINER|INVOKER|NONE. Skipped when a
+            // MySQL-style `SQL SECURITY` was already parsed before VIEW.
+            if security.is_none() {
+                if self.check_identifier("SQL")
+                    && self.current + 1 < self.tokens.len()
+                    && self.tokens[self.current + 1]
+                        .text
+                        .eq_ignore_ascii_case("SECURITY")
+                {
+                    // SQL SECURITY after view name
+                    self.skip(); // consume SQL
+                    self.skip(); // consume SECURITY
+                    security = if self.match_identifier("DEFINER") {
+                        Some(FunctionSecurity::Definer)
+                    } else if self.match_identifier("INVOKER") {
+                        Some(FunctionSecurity::Invoker)
+                    } else if self.match_identifier("NONE") {
+                        Some(FunctionSecurity::None)
+                    } else {
+                        None
+                    };
+                    security_sql_style = true;
+                    security_after_name = true;
+                    continue;
+                } else if self.match_identifier("SECURITY") {
+                    // Presto/Trino-style SECURITY after view name
+                    security = if self.match_identifier("DEFINER") {
+                        Some(FunctionSecurity::Definer)
+                    } else if self.match_identifier("INVOKER") {
+                        Some(FunctionSecurity::Invoker)
+                    } else if self.match_identifier("NONE") {
+                        Some(FunctionSecurity::None)
+                    } else {
+                        None
+                    };
+                    security_sql_style = false;
+                    security_after_name = false;
+                    continue;
+                }
+            }
+
+            // COMMENT 'text' (Trino/Presto) or COMMENT = 'text' (Snowflake).
+            if view_comment.is_none() && self.match_token(TokenType::Comment) {
+                let _ = self.match_token(TokenType::Eq);
+                view_comment = Some(self.expect_string()?);
+                continue;
+            }
+
+            break;
+        }
 
         // Snowflake: TAG (name='value', ...)
         let tags = if self.match_identifier("TAG") {

--- a/crates/polyglot-sql/tests/create_view_security_comment_regression.rs
+++ b/crates/polyglot-sql/tests/create_view_security_comment_regression.rs
@@ -1,0 +1,78 @@
+//! Regression tests for CREATE VIEW with both COMMENT and SECURITY clauses.
+//!
+//! Trino/Presto document the canonical ordering as COMMENT before SECURITY:
+//!   https://trino.io/docs/current/sql/create-view.html
+//!
+//!   CREATE [ OR REPLACE ] VIEW view_name
+//!   [ COMMENT view_comment ]
+//!   [ SECURITY { DEFINER | INVOKER } ]
+//!   AS query
+//!
+//! The parser previously consumed the SECURITY clause before COMMENT, so once a
+//! COMMENT preceded SECURITY the statement failed with
+//! "Invalid expression / Unexpected token". Both orderings must now parse.
+
+use polyglot_sql::dialects::DialectType;
+use polyglot_sql::transpile;
+
+#[test]
+fn trino_view_comment_before_security_definer_parses() {
+    let out = transpile(
+        "CREATE VIEW v COMMENT 'c' SECURITY DEFINER AS SELECT 1 AS a",
+        DialectType::Trino,
+        DialectType::Trino,
+    )
+    .expect("COMMENT before SECURITY DEFINER should parse");
+
+    let sql = &out[0];
+    assert!(sql.contains("SECURITY DEFINER"), "got: {sql}");
+    assert!(sql.to_uppercase().contains("COMMENT"), "got: {sql}");
+}
+
+#[test]
+fn trino_view_comment_before_security_invoker_parses() {
+    transpile(
+        "CREATE VIEW v COMMENT 'c' SECURITY INVOKER AS SELECT 1 AS a",
+        DialectType::Trino,
+        DialectType::Trino,
+    )
+    .expect("COMMENT before SECURITY INVOKER should parse");
+}
+
+#[test]
+fn presto_view_comment_before_security_parses() {
+    transpile(
+        "CREATE VIEW v COMMENT 'c' SECURITY INVOKER AS SELECT 1 AS a",
+        DialectType::Presto,
+        DialectType::Presto,
+    )
+    .expect("Presto COMMENT before SECURITY should parse");
+}
+
+#[test]
+fn trino_view_security_before_comment_still_parses() {
+    // The previously-accepted ordering (SECURITY before COMMENT) must keep working.
+    transpile(
+        "CREATE VIEW v SECURITY DEFINER COMMENT 'c' AS SELECT 1 AS a",
+        DialectType::Trino,
+        DialectType::Trino,
+    )
+    .expect("SECURITY before COMMENT should still parse");
+}
+
+#[test]
+fn trino_view_security_only_and_comment_only_still_parse() {
+    transpile(
+        "CREATE VIEW v SECURITY DEFINER AS SELECT 1 AS a",
+        DialectType::Trino,
+        DialectType::Trino,
+    )
+    .expect("SECURITY only should parse");
+
+    transpile(
+        "CREATE VIEW v COMMENT 'c' AS SELECT 1 AS a",
+        DialectType::Trino,
+        DialectType::Trino,
+    )
+    .expect("COMMENT only should parse");
+}


### PR DESCRIPTION
## Problem

Trino and Presto document the `CREATE VIEW` options with `COMMENT` before `SECURITY`:

```
CREATE [ OR REPLACE ] VIEW view_name
[ COMMENT view_comment ]
[ SECURITY { DEFINER | INVOKER } ]
AS query
```

(https://trino.io/docs/current/sql/create-view.html)

A statement written in that documented order fails to parse:

```
CREATE VIEW v COMMENT 'c' SECURITY DEFINER AS SELECT 1 AS a
-- Parse error at line 1, column 35: Invalid expression / Unexpected token
```

`SECURITY`-only and `COMMENT`-only each parse fine; only the two together, in the documented order, break:

| input (trino) | before |
| --- | --- |
| `CREATE VIEW v SECURITY DEFINER AS SELECT 1 AS a` | ok |
| `CREATE VIEW v COMMENT 'c' AS SELECT 1 AS a` | ok |
| `CREATE VIEW v COMMENT 'c' SECURITY DEFINER AS SELECT 1 AS a` | parse error |
| `CREATE VIEW v COMMENT 'c' SECURITY INVOKER AS SELECT 1 AS a` | parse error |

## Cause

In `parse_create_view_body`, the `SECURITY` clause was parsed before the `COMMENT` clause. With `COMMENT ... SECURITY ...`, the `SECURITY` branch sees the `COMMENT` token and gives up (`security = None`), `COMMENT` is then consumed, and the parser next expects `AS`/`SELECT`/`WITH` but finds the leftover `SECURITY`, yielding the error above. Only the MySQL-style `SECURITY ... COMMENT ...` order was accepted.

## Fix

Parse `SECURITY` and `COMMENT` in a loop so either order is accepted. The previously supported forms keep working:

- Presto/Trino `SECURITY { DEFINER | INVOKER | NONE }`
- MySQL `SQL SECURITY ...` (both before the `VIEW` keyword and after the view name)
- Snowflake `COMMENT = '...'`

The change is confined to `parse_create_view_body`; the generator and AST are untouched.

## Tests

Adds `tests/create_view_security_comment_regression.rs` covering both orders, `COMMENT`-only, `SECURITY`-only, and Presto.

Verified locally with the stable toolchain:

- `cargo test -p polyglot-sql --test create_view_security_comment_regression` — 5 passed
- lib unit tests — 1088 passed
- `identity_roundtrip` (130), `dialect_matrix` (68), `transform_regression` (10), `clickhouse_regression` (22) — no regressions

## Note (out of scope)

Generating back to Trino/Presto still emits `SECURITY ... COMMENT = '...'`, which re-parses correctly with this change but is not the canonical Trino spelling (`COMMENT` first, no `=`). Aligning generator output touches shared multi-dialect code and is left for a separate change; this PR only fixes parsing.

Made with [Cursor](https://cursor.com)