### PR TITLE
feat(sqlite): accept string-literal aliases (AS 'x')

### DIFF
--- a/crates/polyglot-sql/src/parser.rs
+++ b/crates/polyglot-sql/src/parser.rs
@@ -3742,8 +3742,11 @@ impl Parser {
                         }))
                     } else {
                         // Allow keywords as aliases (e.g., SELECT 1 AS filter)
-                        // Use _with_quoted to preserve quoted alias
-                        let alias = self.expect_identifier_or_keyword_with_quoted()?;
+                        // Use _with_quoted to preserve quoted alias.
+                        let alias = match self.try_parse_string_alias() {
+                            Some(ident) => ident,
+                            None => self.expect_identifier_or_keyword_with_quoted()?,
+                        };
                         let mut trailing_comments = self.previous_trailing_comments().to_vec();
                         // If parse_comparison stored pending leading comments (no comparison
                         // followed), use those. Otherwise use the leading_comments we captured
@@ -45137,7 +45140,27 @@ impl Parser {
         }
     }
 
+    /// SQLite/DuckDB allow `AS 'x'` string-literal aliases; normalize to a
+    /// quoted identifier.
+    fn try_parse_string_alias(&mut self) -> Option<Identifier> {
+        use crate::dialects::DialectType;
+
+        let supports_string_aliases = matches!(
+            self.config.dialect,
+            Some(DialectType::DuckDB | DialectType::SQLite)
+        );
+
+        if supports_string_aliases && self.check(TokenType::String) {
+            return Some(Identifier::quoted(self.advance().text));
+        }
+
+        None
+    }
+
     fn expect_identifier_or_alias_keyword_with_quoted(&mut self) -> Result<Identifier> {
+        if let Some(ident) = self.try_parse_string_alias() {
+            return Ok(ident);
+        }
         // ClickHouse: any keyword can be used as a table alias after explicit AS
         let ch_keyword = matches!(
             self.config.dialect,
@@ -45153,20 +45176,6 @@ impl Parser {
             Ok(Identifier {
                 name: token.text,
                 quoted,
-                trailing_comments: Vec::new(),
-                span: None,
-            })
-        } else if self.check(TokenType::String)
-            && matches!(
-                self.config.dialect,
-                Some(crate::dialects::DialectType::DuckDB)
-            )
-        {
-            // DuckDB allows string literals as identifiers (e.g., WITH 'x' AS (...))
-            let token = self.advance();
-            Ok(Identifier {
-                name: token.text,
-                quoted: true,
                 trailing_comments: Vec::new(),
                 span: None,
             })

--- a/crates/polyglot-sql/tests/sqlite_regression.rs
+++ b/crates/polyglot-sql/tests/sqlite_regression.rs
@@ -1,0 +1,52 @@
+use polyglot_sql::{transpile, DialectType, Error};
+
+fn identity(sql: &str, dialect: DialectType) -> String {
+    transpile(sql, dialect, dialect)
+        .expect("round-trip should succeed")
+        .join("; ")
+}
+
+// SQLite/DuckDB allow string-literal aliases; normalized to quoted identifiers.
+#[test]
+fn normalizes_string_literal_aliases() {
+    let cases = [
+        // column alias
+        ("SELECT a AS 'x' FROM t", r#"SELECT a AS "x" FROM t"#),
+        (
+            "SELECT a AS 'record id' FROM t",
+            r#"SELECT a AS "record id" FROM t"#,
+        ),
+        // table alias
+        ("SELECT a FROM t AS 'x'", r#"SELECT a FROM t AS "x""#),
+        // CTE name
+        (
+            "WITH 'x' AS (SELECT 1) SELECT * FROM x",
+            r#"WITH "x" AS (SELECT 1) SELECT * FROM x"#,
+        ),
+    ];
+    for dialect in [DialectType::SQLite, DialectType::DuckDB] {
+        for (input, expected) in cases {
+            assert_eq!(identity(input, dialect), expected, "{dialect:?}: {input}");
+        }
+    }
+}
+
+// Only explicit AS/CTE positions accept string aliases, not `SELECT a 'x'`.
+#[test]
+fn implicit_string_alias_is_not_supported() {
+    for dialect in [DialectType::SQLite, DialectType::DuckDB] {
+        let err = transpile("SELECT a 'x' FROM t", dialect, dialect)
+            .expect_err("implicit string aliases are not supported");
+        assert!(matches!(err, Error::Parse { .. }), "{dialect:?}: {err}");
+    }
+}
+
+// Other dialects treat single quotes as string literals and reject this.
+#[test]
+fn other_dialects_reject_string_literal_aliases() {
+    for dialect in [DialectType::PostgreSQL, DialectType::Snowflake] {
+        let err = transpile("SELECT a AS 'x' FROM t", dialect, dialect)
+            .expect_err("string-literal aliases are not valid here");
+        assert!(matches!(err, Error::Parse { .. }), "{dialect:?}: {err}");
+    }
+}


### PR DESCRIPTION
SQLite and DuckDB accept single-quoted string literals where an alias identifier is expected. The parser rejected them in the column-alias position (`SELECT a AS 'x'`). This normalizes them to canonical quoted identifiers so they round-trip as `"x"`.

## Changes
- Add `try_parse_string_alias()`, used by the SELECT-list column alias and the shared alias helper (table aliases, CTE names). Replaces the prior DuckDB-only string branch.
- The general-purpose identifier helper is left untouched, so string literals are not accepted in non-alias positions.
- Only explicit `AS`/CTE positions are affected; implicit `SELECT a 'x'` still errors.
- Other dialects (PostgreSQL, Snowflake) continue to reject the syntax.

## Before / after (SQLite)
| Input | Before | After |
|---|---|---|
| `SELECT a AS 'x' FROM t` | parse error | `SELECT a AS "x" FROM t` |
| `SELECT a FROM t AS 'x'` | parse error | `SELECT a FROM t AS "x"` |
| `WITH 'x' AS (SELECT 1) ...` | parse error | `WITH "x" AS (SELECT 1) ...` |

Adds `tests/sqlite_regression.rs` covering SQLite/DuckDB normalization, CTE names, implicit-alias rejection, and rejection by PostgreSQL/Snowflake.
