### PR TITLE
fix: infer types for UNNEST output aliases

### DIFF
--- a/crates/polyglot-sql-wasm/src/lib.rs
+++ b/crates/polyglot-sql-wasm/src/lib.rs
@@ -12,7 +12,6 @@ use polyglot_sql::{
     expressions::{BooleanLiteral, DataType, Expression},
     format as core_format, format_with_options as core_format_with_options, get_all_tables,
     lineage::{self, LineageNode},
-    mapping_schema_from_validation_schema,
     openlineage::{
         openlineage_column_lineage as core_openlineage_column_lineage,
         openlineage_job_event as core_openlineage_job_event,
@@ -1402,7 +1401,11 @@ fn lineage_with_schema_internal(
         }
     };
 
-    let mapping_schema = mapping_schema_from_validation_schema(&validation_schema);
+    let mapping_schema = polyglot_sql::query_analysis::mapping_schema_for_expression(
+        &expr,
+        &validation_schema,
+        dialect_type,
+    );
     let dialect_opt = if dialect_type == DialectType::Generic {
         None
     } else {
@@ -1726,17 +1729,17 @@ fn annotate_types_internal(sql: &str, dialect: &str, schema_json: &str) -> Parse
     };
 
     // Parse schema if provided
-    let schema = if !schema_json.is_empty() {
-        match serde_json::from_str::<CoreValidationSchema>(schema_json) {
-            Ok(vs) => Some(mapping_schema_from_validation_schema(&vs)),
-            Err(_) => None,
-        }
+    let validation_schema = if !schema_json.is_empty() {
+        serde_json::from_str::<CoreValidationSchema>(schema_json).ok()
     } else {
         None
     };
 
     // Annotate types on each expression
     for expr in &mut exprs {
+        let schema = validation_schema.as_ref().map(|schema| {
+            polyglot_sql::query_analysis::mapping_schema_for_expression(expr, schema, dialect_type)
+        });
         polyglot_sql::annotate_types(
             expr,
             schema.as_ref().map(|s| s as &dyn polyglot_sql::Schema),
@@ -3428,6 +3431,52 @@ mod tests {
             result.contains("\"name\":\"t.amount\""),
             "Expected qualified downstream lineage with partial schema: {}",
             result
+        );
+    }
+
+    #[test]
+    fn test_lineage_with_schema_infers_unnest_output_element_type() {
+        let schema = r#"{
+            "tables": [
+                {
+                    "name": "events",
+                    "columns": [{"name": "tags", "type": "VARCHAR[]"}]
+                }
+            ]
+        }"#;
+
+        let result = lineage_with_schema_internal(
+            "WITH unnested AS (\
+                SELECT u.tag FROM events e, UNNEST(e.tags) AS u(tag)\
+            ), grouped AS (\
+                SELECT tag, COUNT(*) AS tag_count FROM unnested GROUP BY tag\
+            ) SELECT g.tag FROM grouped g",
+            "tag",
+            schema,
+            "duckdb",
+            false,
+        );
+
+        assert!(result.success, "Result: {:?}", result.error);
+        let inferred_type = result
+            .lineage
+            .as_ref()
+            .and_then(|lineage| lineage.expression.inferred_type());
+        assert!(
+            matches!(inferred_type, Some(DataType::VarChar { .. })),
+            "Inferred type: {inferred_type:?}; lineage: {:?}",
+            result.lineage
+        );
+        let virtual_type = result.lineage.as_ref().and_then(|lineage| {
+            lineage
+                .walk()
+                .find(|node| node.source_kind == polyglot_sql::scope::SourceKind::Virtual)
+                .and_then(|node| node.expression.inferred_type())
+        });
+        assert!(
+            matches!(virtual_type, Some(DataType::VarChar { .. })),
+            "Virtual output type: {virtual_type:?}; lineage: {:?}",
+            result.lineage
         );
     }
 

--- a/crates/polyglot-sql/src/lineage.rs
+++ b/crates/polyglot-sql/src/lineage.rs
@@ -247,7 +247,21 @@ pub fn lineage_with_schema(
     // Pass schema so that stars from external tables can also be resolved.
     expand_cte_stars(&mut qualified_expression, schema);
 
-    lineage_from_expression(column, &qualified_expression, dialect, trim_selects)
+    let mut lineage =
+        lineage_from_expression(column, &qualified_expression, dialect, trim_selects)?;
+    annotate_lineage_node_expressions(&mut lineage, schema, dialect);
+    Ok(lineage)
+}
+
+fn annotate_lineage_node_expressions(
+    node: &mut LineageNode,
+    schema: Option<&dyn Schema>,
+    dialect: Option<DialectType>,
+) {
+    annotate_types(&mut node.expression, schema, dialect);
+    for child in &mut node.downstream {
+        annotate_lineage_node_expressions(child, schema, dialect);
+    }
 }
 
 fn lineage_from_expression(

--- a/crates/polyglot-sql/src/optimizer/annotate_types.rs
+++ b/crates/polyglot-sql/src/optimizer/annotate_types.rs
@@ -663,10 +663,10 @@ impl<'a> TypeAnnotator<'a> {
             }
             Expression::Unnest(unnest) => {
                 // UNNEST(array) - returns the element type of the array
-                if let Some(DataType::Array { element_type, .. }) = self.annotate(&unnest.this) {
-                    Some(*element_type)
-                } else {
-                    None
+                match self.annotate(&unnest.this) {
+                    Some(DataType::Array { element_type, .. })
+                    | Some(DataType::List { element_type }) => Some(*element_type),
+                    _ => None,
                 }
             }
             Expression::Explode(explode) => {
@@ -1245,6 +1245,11 @@ impl<'a> TypeAnnotator<'a> {
 
         // For functions with Unknown return type, infer from arguments
         match func_name.as_str() {
+            "UNNEST" => match func.args.first().and_then(|arg| self.annotate(arg)) {
+                Some(DataType::Array { element_type, .. })
+                | Some(DataType::List { element_type }) => Some(*element_type),
+                _ => None,
+            },
             "COALESCE" | "IFNULL" | "NVL" | "ISNULL" => {
                 // Return type of first non-null argument
                 for arg in &func.args {

--- a/crates/polyglot-sql/src/query_analysis.rs
+++ b/crates/polyglot-sql/src/query_analysis.rs
@@ -9,10 +9,10 @@ use crate::ast_transforms::get_output_column_names;
 use crate::dialects::{Dialect, DialectType};
 use crate::expressions::{DataType, Expression, JoinKind, TableRef, With};
 use crate::lineage::{lineage_by_index_from_expression, LineageNode};
-use crate::optimizer::annotate_types::annotate_types;
+use crate::optimizer::annotate_types::{annotate_types, TypeAnnotator};
 use crate::optimizer::qualify_columns::{qualify_columns, QualifyColumnsOptions};
 use crate::schema::{MappingSchema, Schema};
-use crate::scope::{build_scope, Scope, SourceInfo, SourceKind};
+use crate::scope::{build_scope, Scope, ScopeType, SourceInfo, SourceKind};
 use crate::traversal::{contains_aggregate, ExpressionWalk};
 use crate::validation::{mapping_schema_from_validation_schema, ValidationSchema};
 use crate::{parse_data_type, parse_one, Error, Result};
@@ -194,16 +194,9 @@ pub fn analyze_query(sql: &str, options: AnalyzeQueryOptions) -> Result<QueryAna
             .map_err(|e| Error::internal(format!("query analysis qualification failed: {e}")))?;
     }
 
-    let annotation_schema = mapping_schema.as_ref().map(|schema| {
-        let mut alias_schema = schema.clone();
-        add_scope_aliases_to_schema(
-            &build_scope(&expression),
-            schema,
-            &mut alias_schema,
-            options.dialect,
-        );
-        alias_schema
-    });
+    let annotation_schema = mapping_schema
+        .as_ref()
+        .map(|schema| schema_with_scope_aliases(&expression, schema, options.dialect));
 
     annotate_types(
         &mut expression,
@@ -309,6 +302,41 @@ fn parse_analysis_data_type(data_type: &str, dialect: DialectType) -> Option<Dat
     parse_data_type(trimmed, dialect).ok()
 }
 
+/// Build a precise schema for type annotation of a parsed expression.
+///
+/// Unlike the validation resolver schema, this preserves nested element types and adds
+/// relation aliases introduced by the SQL itself.
+#[doc(hidden)]
+pub fn mapping_schema_for_expression(
+    expression: &Expression,
+    schema: &ValidationSchema,
+    dialect: DialectType,
+) -> MappingSchema {
+    let source_schema = analysis_mapping_schema(schema, dialect);
+    schema_with_scope_aliases(expression, &source_schema, dialect)
+}
+
+/// Add SQL relation aliases, including typed virtual `UNNEST` outputs, to a schema.
+///
+/// This prepares a concrete schema for APIs that annotate an already-parsed expression.
+/// Physical relation aliases are installed before virtual relations so expressions such as
+/// `UNNEST(e.tags) AS u(tag)` can resolve the element type through `e`.
+#[doc(hidden)]
+pub fn schema_with_scope_aliases(
+    expression: &Expression,
+    source_schema: &MappingSchema,
+    dialect: DialectType,
+) -> MappingSchema {
+    let mut target_schema = source_schema.clone();
+    add_scope_aliases_to_schema(
+        &build_scope(expression),
+        source_schema,
+        &mut target_schema,
+        dialect,
+    );
+    target_schema
+}
+
 fn add_scope_aliases_to_schema(
     scope: &Scope,
     source_schema: &MappingSchema,
@@ -341,6 +369,198 @@ fn add_scope_aliases_to_schema(
             }
         }
     }
+
+    for child_scope in scope.traverse() {
+        for (source_name, source) in &child_scope.sources {
+            if source.kind != SourceKind::Virtual {
+                continue;
+            }
+            if let Some(columns) =
+                virtual_source_columns(&source.expression, target_schema, dialect)
+            {
+                let _ = target_schema.add_table(source_name, &columns, Some(dialect));
+                if let Some(lineage_name) = source
+                    .lineage_name
+                    .as_deref()
+                    .filter(|lineage_name| *lineage_name != source_name)
+                {
+                    let _ = target_schema.add_table(lineage_name, &columns, Some(dialect));
+                }
+            }
+        }
+    }
+
+    for child_scope in scope.traverse() {
+        if child_scope.scope_type != ScopeType::Cte {
+            continue;
+        }
+        let Expression::Cte(cte) = &child_scope.expression else {
+            continue;
+        };
+        if let Some(columns) = query_output_columns(&cte.this, target_schema, dialect) {
+            let columns = apply_output_aliases(columns, &cte.columns);
+            let _ = target_schema.add_table(&cte.alias.name, &columns, Some(dialect));
+        }
+    }
+
+    for child_scope in scope.traverse() {
+        for (source_name, source) in &child_scope.sources {
+            if !matches!(source.kind, SourceKind::Cte | SourceKind::DerivedTable) {
+                continue;
+            }
+            let columns = match &source.expression {
+                Expression::Cte(cte) => schema_table_columns(target_schema, &cte.alias.name),
+                expression => query_source_columns(expression, target_schema, dialect),
+            };
+            if let Some(columns) = columns {
+                let _ = target_schema.add_table(source_name, &columns, Some(dialect));
+            }
+        }
+    }
+}
+
+fn schema_table_columns(
+    schema: &MappingSchema,
+    table_name: &str,
+) -> Option<Vec<(String, DataType)>> {
+    Some(
+        schema
+            .column_names(table_name)
+            .ok()?
+            .into_iter()
+            .map(|column| {
+                let data_type = schema
+                    .get_column_type(table_name, &column)
+                    .unwrap_or(DataType::Unknown);
+                (column, data_type)
+            })
+            .collect(),
+    )
+}
+
+fn query_source_columns(
+    expression: &Expression,
+    schema: &MappingSchema,
+    dialect: DialectType,
+) -> Option<Vec<(String, DataType)>> {
+    match expression {
+        Expression::Subquery(subquery) => {
+            let columns = query_output_columns(&subquery.this, schema, dialect)?;
+            Some(apply_output_aliases(columns, &subquery.column_aliases))
+        }
+        Expression::Alias(alias) => {
+            let columns = query_output_columns(&alias.this, schema, dialect)?;
+            Some(apply_output_aliases(columns, &alias.column_aliases))
+        }
+        _ => None,
+    }
+}
+
+fn query_output_columns(
+    expression: &Expression,
+    schema: &MappingSchema,
+    dialect: DialectType,
+) -> Option<Vec<(String, DataType)>> {
+    let qualify_options = QualifyColumnsOptions::new()
+        .with_dialect(dialect)
+        .with_allow_partial(true);
+    let mut expression = qualify_columns(expression.clone(), schema, &qualify_options)
+        .unwrap_or_else(|_| expression.clone());
+    annotate_types(&mut expression, Some(schema), Some(dialect));
+    typed_query_outputs(&expression)
+}
+
+fn typed_query_outputs(expression: &Expression) -> Option<Vec<(String, DataType)>> {
+    match expression {
+        Expression::Select(select) => Some(
+            select
+                .expressions
+                .iter()
+                .filter_map(|projection| {
+                    let name = projection_name(projection)?;
+                    let data_type = projection
+                        .inferred_type()
+                        .or_else(|| unwrap_projection_alias(projection).inferred_type())
+                        .cloned()
+                        .unwrap_or(DataType::Unknown);
+                    Some((name, data_type))
+                })
+                .collect(),
+        ),
+        Expression::Union(set_operation) => typed_query_outputs(&set_operation.left),
+        Expression::Intersect(set_operation) => typed_query_outputs(&set_operation.left),
+        Expression::Except(set_operation) => typed_query_outputs(&set_operation.left),
+        Expression::Cte(cte) => typed_query_outputs(&cte.this),
+        Expression::Subquery(subquery) => typed_query_outputs(&subquery.this),
+        Expression::Paren(paren) => typed_query_outputs(&paren.this),
+        _ => None,
+    }
+}
+
+fn apply_output_aliases(
+    mut columns: Vec<(String, DataType)>,
+    aliases: &[crate::expressions::Identifier],
+) -> Vec<(String, DataType)> {
+    for (column, alias) in columns.iter_mut().zip(aliases) {
+        column.0 = alias.name.clone();
+    }
+    columns
+}
+
+fn virtual_source_columns(
+    expression: &Expression,
+    schema: &MappingSchema,
+    dialect: DialectType,
+) -> Option<Vec<(String, DataType)>> {
+    let (unnest, output_names) = match expression {
+        Expression::Alias(alias) => {
+            let Expression::Unnest(unnest) = &alias.this else {
+                return None;
+            };
+            let output_names = if alias.column_aliases.is_empty() {
+                vec![alias.alias.name.clone()]
+            } else {
+                alias
+                    .column_aliases
+                    .iter()
+                    .map(|column| column.name.clone())
+                    .collect()
+            };
+            (unnest.as_ref(), output_names)
+        }
+        Expression::Unnest(unnest) => {
+            let output_names = unnest
+                .alias
+                .iter()
+                .map(|alias| alias.name.clone())
+                .chain(unnest.offset_alias.iter().map(|alias| alias.name.clone()))
+                .collect();
+            (unnest.as_ref(), output_names)
+        }
+        _ => return None,
+    };
+
+    if output_names.is_empty() {
+        return None;
+    }
+
+    let mut annotator = TypeAnnotator::new(Some(schema), Some(dialect));
+    let mut output_types = std::iter::once(&unnest.this)
+        .chain(unnest.expressions.iter())
+        .map(|argument| match annotator.annotate(argument) {
+            Some(DataType::Array { element_type, .. }) | Some(DataType::List { element_type }) => {
+                *element_type
+            }
+            _ => DataType::Unknown,
+        })
+        .collect::<Vec<_>>();
+
+    if unnest.with_ordinality || unnest.offset_alias.is_some() {
+        output_types.push(DataType::BigInt { length: None });
+    }
+    output_types.resize(output_names.len(), DataType::Unknown);
+
+    Some(output_names.into_iter().zip(output_types).collect())
 }
 
 #[derive(Debug, Clone)]

--- a/crates/polyglot-sql/tests/query_analysis.rs
+++ b/crates/polyglot-sql/tests/query_analysis.rs
@@ -628,7 +628,7 @@ fn unnest_analysis_schema() -> ValidationSchema {
         "tables": [
             {
                 "name": "t",
-                "columns": [{"name": "arr", "type": "INT"}]
+                "columns": [{"name": "arr", "type": "VARCHAR[]"}]
             }
         ]
     }))
@@ -714,6 +714,8 @@ fn analyze_query_resolves_unnest_virtual_output_aliases_with_schema() {
         "SELECT i FROM t, UNNEST(t.arr) AS i",
         "SELECT i FROM t, UNNEST(t.arr) AS u(i)",
         "SELECT u.i FROM t, UNNEST(t.arr) AS u(i)",
+        "SELECT u.i FROM t AS e, UNNEST(e.arr) AS u(i)",
+        "SELECT UNNEST(t.arr) AS i FROM t",
     ] {
         let analysis = analyze_query(
             sql,
@@ -733,7 +735,31 @@ fn analyze_query_resolves_unnest_virtual_output_aliases_with_schema() {
             "expected t.arr upstream for {sql:?}, got {:?}",
             analysis.projections[0].upstream
         );
+        assert_eq!(
+            analysis.projections[0].type_hint.as_deref(),
+            Some("TEXT"),
+            "expected scalar element type for {sql:?}"
+        );
     }
+}
+
+#[test]
+fn analyze_query_propagates_unnest_element_type_through_cte() {
+    let analysis = analyze_query(
+        "WITH unnested AS (\
+            SELECT u.tag FROM t, UNNEST(t.arr) AS u(tag)\
+        ), grouped AS (\
+            SELECT tag, COUNT(*) AS tag_count FROM unnested GROUP BY tag\
+        ) SELECT g.tag, g.tag_count FROM grouped g",
+        AnalyzeQueryOptions {
+            dialect: DialectType::DuckDB,
+            schema: Some(unnest_analysis_schema()),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(analysis.projections[0].type_hint.as_deref(), Some("TEXT"));
+    assert_eq!(analysis.projections[1].type_hint.as_deref(), Some("BIGINT"));
 }
 
 #[test]

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -385,6 +385,31 @@ describe('Polyglot SDK', () => {
       expect(collectNames(result.lineage!)).toContain('t.amount');
     });
 
+    it('should infer the scalar type of an UNNEST output alias', () => {
+      const result = lineageWithSchema(
+        'tag',
+        `WITH unnested AS (
+          SELECT u.tag FROM events e, UNNEST(e.tags) AS u(tag)
+        ), grouped AS (
+          SELECT tag, COUNT(*) AS tag_count FROM unnested GROUP BY tag
+        ) SELECT g.tag FROM grouped g`,
+        {
+          tables: [
+            {
+              name: 'events',
+              columns: [{ name: 'tags', type: 'VARCHAR[]' }],
+            },
+          ],
+        },
+        Dialect.DuckDB,
+      );
+
+      expect(result.success).toBe(true);
+      expect(sdk.ast.getInferredType(result.lineage!.expression)).toEqual(
+        expect.objectContaining({ data_type: 'var_char' }),
+      );
+    });
+
     it('should trace unpivot value columns to input columns', () => {
       const result = lineage(
         'val',
@@ -564,17 +589,26 @@ describe('Polyglot SDK', () => {
     });
 
     it('should resolve UNNEST output alias with schema', () => {
-      const result = analyzeQuery('SELECT i FROM t, UNNEST(t.arr) AS i', {
-        dialect: Dialect.DuckDB,
-        schema: {
-          tables: [{ name: 't', columns: [{ name: 'arr', type: 'INT' }] }],
+      const result = analyzeQuery(
+        'SELECT u.tag FROM events e, UNNEST(e.tags) AS u(tag)',
+        {
+          dialect: Dialect.DuckDB,
+          schema: {
+            tables: [
+              {
+                name: 'events',
+                columns: [{ name: 'tags', type: 'VARCHAR[]' }],
+              },
+            ],
+          },
         },
-      });
+      );
 
       expect(result.success).toBe(true);
+      expect(result.analysis?.projections[0].typeHint).toBe('TEXT');
       expect(result.analysis?.projections[0].upstream).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ table: 't', column: 'arr' }),
+          expect.objectContaining({ table: 'events', column: 'tags' }),
         ]),
       );
     });


### PR DESCRIPTION
## Summary

- preserve nested schema types when preparing query-analysis and WASM annotation schemas
- materialize typed `UNNEST` virtual outputs under both user-written and canonical lineage aliases
- propagate inferred output types through sequential CTE and derived-table aliases
- annotate generated lineage-node expressions so consumers receive the scalar element type

## Reproduction

Given `events.tags` with type `VARCHAR[]`:

```sql
WITH unnested AS (
  SELECT u.tag
  FROM events e, UNNEST(e.tags) AS u(tag)
), grouped AS (
  SELECT tag, COUNT(*) AS tag_count
  FROM unnested
  GROUP BY tag
)
SELECT g.tag
FROM grouped g
```

Previously, the `UNNEST` output alias and the projections derived from it had no inferred type. After this change, `analyzeQuery` reports `TEXT` and `lineageWithSchema` exposes the scalar `var_char` type while preserving `events.tags` as the physical upstream column.

## Validation

- `cargo test -p polyglot-sql --test query_analysis`
- `cargo test -p polyglot-sql-wasm`
- `cargo check -p polyglot-sql -p polyglot-sql-wasm`
- `cargo fmt --all -- --check`
- `pnpm run typecheck` (`packages/sdk`)
- `pnpm run lint` (`packages/sdk`)
- `pnpm exec vitest run src/index.test.ts` (`packages/sdk`, 71 tests)

Fixes #372
