### PR TITLE
Fix strict Fabric/TSQL validation for PostgreSQL dates and subqueries

### DIFF
--- a/crates/polyglot-sql/src/dialects/mod.rs
+++ b/crates/polyglot-sql/src/dialects/mod.rs
@@ -4294,6 +4294,12 @@ impl Dialect {
                         "qualified whole-row aggregate arguments",
                     );
                 }
+                if Self::node_has_subquery_in_aggregate_argument(node) {
+                    Self::push_unsupported_diagnostic(
+                        &mut diagnostics,
+                        "aggregate arguments containing subqueries",
+                    );
+                }
             }
 
             if !Self::target_supports_distinct_on(target) && Self::node_has_distinct_on(node) {
@@ -5177,6 +5183,21 @@ impl Dialect {
 
         Self::node_is_aggregate_function(expr)
             && expr.children().into_iter().any(contains_qualified_star)
+    }
+
+    fn node_has_subquery_in_aggregate_argument(expr: &Expression) -> bool {
+        fn contains_query(expr: &Expression) -> bool {
+            matches!(
+                expr,
+                Expression::Select(_)
+                    | Expression::Subquery(_)
+                    | Expression::Union(_)
+                    | Expression::Intersect(_)
+                    | Expression::Except(_)
+            ) || expr.children().into_iter().any(contains_query)
+        }
+
+        Self::node_is_aggregate_function(expr) && expr.children().into_iter().any(contains_query)
     }
 
     fn tsql_apply_has_invalid_outer_aggregate(expr: &Expression) -> bool {

--- a/crates/polyglot-sql/src/generator.rs
+++ b/crates/polyglot-sql/src/generator.rs
@@ -37824,7 +37824,6 @@ impl Generator {
                     DataType::Char { length } => Some(Self::postgres_string_cast_literal(
                         value,
                         length.unwrap_or(1),
-                        true,
                     )),
                     DataType::VarChar {
                         length: Some(length),
@@ -37832,9 +37831,9 @@ impl Generator {
                     }
                     | DataType::String {
                         length: Some(length),
-                    } => Some(Self::postgres_string_cast_literal(value, *length, false)),
+                    } => Some(Self::postgres_string_cast_literal(value, *length)),
                     DataType::TextWithLength { length } => {
-                        Some(Self::postgres_string_cast_literal(value, *length, false))
+                        Some(Self::postgres_string_cast_literal(value, *length))
                     }
                     _ => Some(value),
                 }
@@ -37843,22 +37842,11 @@ impl Generator {
         }
     }
 
-    fn postgres_string_cast_literal(
-        value: Cow<'_, str>,
-        length: u32,
-        blank_pad: bool,
-    ) -> Cow<'_, str> {
+    fn postgres_string_cast_literal(value: Cow<'_, str>, length: u32) -> Cow<'_, str> {
         let length = length as usize;
         let value_length = value.chars().count();
-        if value_length > length || (blank_pad && value_length < length) {
-            let mut result = value.chars().take(length).collect::<String>();
-            if blank_pad {
-                result.extend(std::iter::repeat_n(
-                    ' ',
-                    length.saturating_sub(value_length),
-                ));
-            }
-            Cow::Owned(result)
+        if value_length > length {
+            Cow::Owned(value.chars().take(length).collect())
         } else {
             value
         }

--- a/crates/polyglot-sql/src/generator.rs
+++ b/crates/polyglot-sql/src/generator.rs
@@ -37810,18 +37810,57 @@ impl Generator {
         }
     }
 
-    fn postgres_tsql_literal_string(expr: &Expression) -> Option<&str> {
+    fn postgres_tsql_literal_string(expr: &Expression) -> Option<Cow<'_, str>> {
         match expr {
             Expression::Literal(literal) => match literal.as_ref() {
-                Literal::String(value) => Some(value),
+                Literal::String(value) => Some(Cow::Borrowed(value)),
                 _ => None,
             },
             Expression::Cast(cast) | Expression::TryCast(cast) | Expression::SafeCast(cast)
                 if Self::is_string_data_type(&cast.to) =>
             {
-                Self::postgres_tsql_literal_string(&cast.this)
+                let value = Self::postgres_tsql_literal_string(&cast.this)?;
+                match &cast.to {
+                    DataType::Char { length } => Some(Self::postgres_string_cast_literal(
+                        value,
+                        length.unwrap_or(1),
+                        true,
+                    )),
+                    DataType::VarChar {
+                        length: Some(length),
+                        ..
+                    }
+                    | DataType::String {
+                        length: Some(length),
+                    } => Some(Self::postgres_string_cast_literal(value, *length, false)),
+                    DataType::TextWithLength { length } => {
+                        Some(Self::postgres_string_cast_literal(value, *length, false))
+                    }
+                    _ => Some(value),
+                }
             }
             _ => None,
+        }
+    }
+
+    fn postgres_string_cast_literal(
+        value: Cow<'_, str>,
+        length: u32,
+        blank_pad: bool,
+    ) -> Cow<'_, str> {
+        let length = length as usize;
+        let value_length = value.chars().count();
+        if value_length > length || (blank_pad && value_length < length) {
+            let mut result = value.chars().take(length).collect::<String>();
+            if blank_pad {
+                result.extend(std::iter::repeat_n(
+                    ' ',
+                    length.saturating_sub(value_length),
+                ));
+            }
+            Cow::Owned(result)
+        } else {
+            value
         }
     }
 
@@ -37907,7 +37946,7 @@ impl Generator {
                     && matches!(self.config.source_dialect, Some(DialectType::PostgreSQL))
                 {
                     if let Some(value) = Self::postgres_tsql_literal_string(this) {
-                        if Self::postgres_year_is_outside_tsql_range(value, format) {
+                        if Self::postgres_year_is_outside_tsql_range(&value, format) {
                             self.unsupported(
                                 "PostgreSQL TO_DATE literal is outside the T-SQL/Fabric DATE range 0001-01-01 through 9999-12-31",
                             )?;

--- a/crates/polyglot-sql/src/generator.rs
+++ b/crates/polyglot-sql/src/generator.rs
@@ -37810,6 +37810,21 @@ impl Generator {
         }
     }
 
+    fn postgres_tsql_literal_string(expr: &Expression) -> Option<&str> {
+        match expr {
+            Expression::Literal(literal) => match literal.as_ref() {
+                Literal::String(value) => Some(value),
+                _ => None,
+            },
+            Expression::Cast(cast) | Expression::TryCast(cast) | Expression::SafeCast(cast)
+                if Self::is_string_data_type(&cast.to) =>
+            {
+                Self::postgres_tsql_literal_string(&cast.this)
+            }
+            _ => None,
+        }
+    }
+
     fn postgres_year_is_outside_tsql_range(value: &str, format: &str) -> bool {
         fn component_is_outside(component: &str, forced_negative: bool) -> bool {
             let component = component.trim().trim_end_matches(',');
@@ -37891,13 +37906,11 @@ impl Generator {
                 if target_type == "DATE"
                     && matches!(self.config.source_dialect, Some(DialectType::PostgreSQL))
                 {
-                    if let Expression::Literal(literal) = this {
-                        if let Literal::String(value) = literal.as_ref() {
-                            if Self::postgres_year_is_outside_tsql_range(value, format) {
-                                self.unsupported(
-                                    "PostgreSQL TO_DATE literal is outside the T-SQL/Fabric DATE range 0001-01-01 through 9999-12-31",
-                                )?;
-                            }
+                    if let Some(value) = Self::postgres_tsql_literal_string(this) {
+                        if Self::postgres_year_is_outside_tsql_range(value, format) {
+                            self.unsupported(
+                                "PostgreSQL TO_DATE literal is outside the T-SQL/Fabric DATE range 0001-01-01 through 9999-12-31",
+                            )?;
                         }
                     }
                 }

--- a/crates/polyglot-sql/tests/fabric_regression.rs
+++ b/crates/polyglot-sql/tests/fabric_regression.rs
@@ -888,6 +888,8 @@ fn postgres_to_date_literals_respect_fabric_date_domain() {
     for sql in [
         "SELECT to_date('-44-02-01', 'YYYY-MM-DD')",
         "SELECT to_date('0000-02-01', 'YYYY-MM-DD')",
+        "SELECT to_date('-44-02-01'::text, 'YYYY-MM-DD'::text)",
+        "SELECT to_date('0000-02-01'::text, 'YYYY-MM-DD'::text)",
         "SELECT to_date('10000-02-01', 'YYYY-MM-DD')",
         "SELECT to_date('02/01/0000', 'MM/DD/YYYY')",
         "SELECT to_date('00000201', 'YYYYMMDD')",
@@ -917,6 +919,16 @@ fn postgres_to_date_literals_respect_fabric_date_domain() {
         ),
     ] {
         assert_eq!(pg_to_fabric_strict(sql), expected, "failed for {sql}");
+    }
+
+    for sql in [
+        "SELECT to_date('0001-01-01'::text, 'YYYY-MM-DD'::text)",
+        "SELECT to_date('9999-12-31'::text, 'YYYY-MM-DD'::text)",
+        "SELECT to_date(date_text::text, 'YYYY-MM-DD'::text) FROM t",
+    ] {
+        Dialect::get(DialectType::PostgreSQL)
+            .transpile_with(sql, DialectType::Fabric, TranspileOptions::strict())
+            .unwrap_or_else(|err| panic!("strict mode should accept {sql}: {err}"));
     }
 }
 
@@ -2316,6 +2328,33 @@ fn strict_postgres_distinct_string_agg_is_rejected_for_fabric() {
             TranspileOptions::strict(),
         )
         .is_ok());
+}
+
+#[test]
+fn strict_postgres_aggregate_arguments_containing_subqueries_are_rejected_for_fabric() {
+    let pg = Dialect::get(DialectType::PostgreSQL);
+    for sql in [
+        "SELECT (SELECT max((SELECT i.unique2 FROM tenk1 i WHERE i.unique1 = o.unique1))) FROM tenk1 o",
+        "SELECT (SELECT max((SELECT i.unique2 FROM tenk1 i WHERE i.unique1 = o.unique1)) FILTER (WHERE o.unique1 < 10)) FROM tenk1 o",
+        "SELECT sum(unique1) FILTER (WHERE unique1 IN (SELECT unique1 FROM onek WHERE unique1 < 100)) FROM tenk1",
+    ] {
+        let err = pg
+            .transpile_with(sql, DialectType::Fabric, TranspileOptions::strict())
+            .expect_err("strict Fabric transpilation should reject a subquery in an aggregate argument");
+        assert!(
+            err.to_string()
+                .contains("aggregate arguments containing subqueries"),
+            "unexpected error for {sql}: {err}"
+        );
+    }
+
+    for sql in [
+        "SELECT (SELECT i.unique2 FROM tenk1 i WHERE i.unique1 = o.unique1) FROM tenk1 o",
+        "SELECT (SELECT max(i.unique2) FROM tenk1 i WHERE i.unique1 = o.unique1) FROM tenk1 o",
+    ] {
+        pg.transpile_with(sql, DialectType::Fabric, TranspileOptions::strict())
+            .unwrap_or_else(|err| panic!("strict mode should accept {sql}: {err}"));
+    }
 }
 
 #[test]

--- a/crates/polyglot-sql/tests/fabric_regression.rs
+++ b/crates/polyglot-sql/tests/fabric_regression.rs
@@ -890,6 +890,8 @@ fn postgres_to_date_literals_respect_fabric_date_domain() {
         "SELECT to_date('0000-02-01', 'YYYY-MM-DD')",
         "SELECT to_date('-44-02-01'::text, 'YYYY-MM-DD'::text)",
         "SELECT to_date('0000-02-01'::text, 'YYYY-MM-DD'::text)",
+        "SELECT to_date('0001-01-01'::char(1), 'YYYY-MM-DD'::text)",
+        "SELECT to_date('0001-01-01'::varchar(1), 'YYYY-MM-DD'::text)",
         "SELECT to_date('10000-02-01', 'YYYY-MM-DD')",
         "SELECT to_date('02/01/0000', 'MM/DD/YYYY')",
         "SELECT to_date('00000201', 'YYYYMMDD')",
@@ -921,14 +923,21 @@ fn postgres_to_date_literals_respect_fabric_date_domain() {
         assert_eq!(pg_to_fabric_strict(sql), expected, "failed for {sql}");
     }
 
-    for sql in [
-        "SELECT to_date('0001-01-01'::text, 'YYYY-MM-DD'::text)",
-        "SELECT to_date('9999-12-31'::text, 'YYYY-MM-DD'::text)",
-        "SELECT to_date(date_text::text, 'YYYY-MM-DD'::text) FROM t",
+    for (sql, expected) in [
+        (
+            "SELECT to_date('0001-01-01'::text, 'YYYY-MM-DD'::text)",
+            "SELECT CONVERT(DATE, CAST('0001-01-01' AS VARCHAR(MAX)), 23)",
+        ),
+        (
+            "SELECT to_date('9999-12-31'::text, 'YYYY-MM-DD'::text)",
+            "SELECT CONVERT(DATE, CAST('9999-12-31' AS VARCHAR(MAX)), 23)",
+        ),
+        (
+            "SELECT to_date(date_text::text, 'YYYY-MM-DD'::text) FROM t",
+            "SELECT CONVERT(DATE, CAST(date_text AS VARCHAR(MAX)), 23) FROM t",
+        ),
     ] {
-        Dialect::get(DialectType::PostgreSQL)
-            .transpile_with(sql, DialectType::Fabric, TranspileOptions::strict())
-            .unwrap_or_else(|err| panic!("strict mode should accept {sql}: {err}"));
+        assert_eq!(pg_to_fabric_strict(sql), expected, "failed for {sql}");
     }
 }
 

--- a/crates/polyglot-sql/tests/fabric_regression.rs
+++ b/crates/polyglot-sql/tests/fabric_regression.rs
@@ -919,6 +919,14 @@ fn postgres_to_date_literals_respect_fabric_date_domain() {
             "SELECT to_date(date_text, 'YYYY-MM-DD') FROM t",
             "SELECT CONVERT(DATE, date_text, 23) FROM t",
         ),
+        (
+            "SELECT to_date('1'::char(-1), 'YYYY-MM-DD')",
+            "SELECT CONVERT(DATE, CAST('1' AS CHAR(4294967295)), 23)",
+        ),
+        (
+            "SELECT to_date('1'::char(4294967295), 'YYYY-MM-DD')",
+            "SELECT CONVERT(DATE, CAST('1' AS CHAR(4294967295)), 23)",
+        ),
     ] {
         assert_eq!(pg_to_fabric_strict(sql), expected, "failed for {sql}");
     }

--- a/crates/polyglot-sql/tests/tsql_regression.rs
+++ b/crates/polyglot-sql/tests/tsql_regression.rs
@@ -913,6 +913,8 @@ fn postgres_to_date_literals_respect_tsql_date_domain() {
     for sql in [
         "SELECT to_date('-44-02-01', 'YYYY-MM-DD')",
         "SELECT to_date('0000-02-01', 'YYYY-MM-DD')",
+        "SELECT to_date('-44-02-01'::text, 'YYYY-MM-DD'::text)",
+        "SELECT to_date('0000-02-01'::text, 'YYYY-MM-DD'::text)",
         "SELECT to_date('10000-02-01', 'YYYY-MM-DD')",
         "SELECT to_date('02/01/0000', 'MM/DD/YYYY')",
         "SELECT to_date('00000201', 'YYYYMMDD')",
@@ -942,6 +944,16 @@ fn postgres_to_date_literals_respect_tsql_date_domain() {
         ),
     ] {
         assert_eq!(pg_to_tsql_strict(sql), expected, "failed for {sql}");
+    }
+
+    for sql in [
+        "SELECT to_date('0001-01-01'::text, 'YYYY-MM-DD'::text)",
+        "SELECT to_date('9999-12-31'::text, 'YYYY-MM-DD'::text)",
+        "SELECT to_date(date_text::text, 'YYYY-MM-DD'::text) FROM t",
+    ] {
+        Dialect::get(DialectType::PostgreSQL)
+            .transpile_with(sql, DialectType::TSQL, TranspileOptions::strict())
+            .unwrap_or_else(|err| panic!("strict mode should accept {sql}: {err}"));
     }
 }
 
@@ -2540,6 +2552,33 @@ fn strict_postgres_distinct_string_agg_is_rejected_for_tsql() {
             TranspileOptions::strict(),
         )
         .is_ok());
+}
+
+#[test]
+fn strict_postgres_aggregate_arguments_containing_subqueries_are_rejected_for_tsql() {
+    let pg = Dialect::get(DialectType::PostgreSQL);
+    for sql in [
+        "SELECT (SELECT max((SELECT i.unique2 FROM tenk1 i WHERE i.unique1 = o.unique1))) FROM tenk1 o",
+        "SELECT (SELECT max((SELECT i.unique2 FROM tenk1 i WHERE i.unique1 = o.unique1)) FILTER (WHERE o.unique1 < 10)) FROM tenk1 o",
+        "SELECT sum(unique1) FILTER (WHERE unique1 IN (SELECT unique1 FROM onek WHERE unique1 < 100)) FROM tenk1",
+    ] {
+        let err = pg
+            .transpile_with(sql, DialectType::TSQL, TranspileOptions::strict())
+            .expect_err("strict T-SQL transpilation should reject a subquery in an aggregate argument");
+        assert!(
+            err.to_string()
+                .contains("aggregate arguments containing subqueries"),
+            "unexpected error for {sql}: {err}"
+        );
+    }
+
+    for sql in [
+        "SELECT (SELECT i.unique2 FROM tenk1 i WHERE i.unique1 = o.unique1) FROM tenk1 o",
+        "SELECT (SELECT max(i.unique2) FROM tenk1 i WHERE i.unique1 = o.unique1) FROM tenk1 o",
+    ] {
+        pg.transpile_with(sql, DialectType::TSQL, TranspileOptions::strict())
+            .unwrap_or_else(|err| panic!("strict mode should accept {sql}: {err}"));
+    }
 }
 
 #[test]

--- a/crates/polyglot-sql/tests/tsql_regression.rs
+++ b/crates/polyglot-sql/tests/tsql_regression.rs
@@ -944,6 +944,14 @@ fn postgres_to_date_literals_respect_tsql_date_domain() {
             "SELECT to_date(date_text, 'YYYY-MM-DD') FROM t",
             "SELECT CONVERT(DATE, date_text, 23) FROM t",
         ),
+        (
+            "SELECT to_date('1'::char(-1), 'YYYY-MM-DD')",
+            "SELECT CONVERT(DATE, CAST('1' AS CHAR(4294967295)), 23)",
+        ),
+        (
+            "SELECT to_date('1'::char(4294967295), 'YYYY-MM-DD')",
+            "SELECT CONVERT(DATE, CAST('1' AS CHAR(4294967295)), 23)",
+        ),
     ] {
         assert_eq!(pg_to_tsql_strict(sql), expected, "failed for {sql}");
     }

--- a/crates/polyglot-sql/tests/tsql_regression.rs
+++ b/crates/polyglot-sql/tests/tsql_regression.rs
@@ -915,6 +915,8 @@ fn postgres_to_date_literals_respect_tsql_date_domain() {
         "SELECT to_date('0000-02-01', 'YYYY-MM-DD')",
         "SELECT to_date('-44-02-01'::text, 'YYYY-MM-DD'::text)",
         "SELECT to_date('0000-02-01'::text, 'YYYY-MM-DD'::text)",
+        "SELECT to_date('0001-01-01'::char(1), 'YYYY-MM-DD'::text)",
+        "SELECT to_date('0001-01-01'::varchar(1), 'YYYY-MM-DD'::text)",
         "SELECT to_date('10000-02-01', 'YYYY-MM-DD')",
         "SELECT to_date('02/01/0000', 'MM/DD/YYYY')",
         "SELECT to_date('00000201', 'YYYYMMDD')",
@@ -946,14 +948,21 @@ fn postgres_to_date_literals_respect_tsql_date_domain() {
         assert_eq!(pg_to_tsql_strict(sql), expected, "failed for {sql}");
     }
 
-    for sql in [
-        "SELECT to_date('0001-01-01'::text, 'YYYY-MM-DD'::text)",
-        "SELECT to_date('9999-12-31'::text, 'YYYY-MM-DD'::text)",
-        "SELECT to_date(date_text::text, 'YYYY-MM-DD'::text) FROM t",
+    for (sql, expected) in [
+        (
+            "SELECT to_date('0001-01-01'::text, 'YYYY-MM-DD'::text)",
+            "SELECT CONVERT(DATE, CAST('0001-01-01' AS VARCHAR(MAX)), 23)",
+        ),
+        (
+            "SELECT to_date('9999-12-31'::text, 'YYYY-MM-DD'::text)",
+            "SELECT CONVERT(DATE, CAST('9999-12-31' AS VARCHAR(MAX)), 23)",
+        ),
+        (
+            "SELECT to_date(date_text::text, 'YYYY-MM-DD'::text) FROM t",
+            "SELECT CONVERT(DATE, CAST(date_text AS VARCHAR(MAX)), 23) FROM t",
+        ),
     ] {
-        Dialect::get(DialectType::PostgreSQL)
-            .transpile_with(sql, DialectType::TSQL, TranspileOptions::strict())
-            .unwrap_or_else(|err| panic!("strict mode should accept {sql}: {err}"));
+        assert_eq!(pg_to_tsql_strict(sql), expected, "failed for {sql}");
     }
 }
 


### PR DESCRIPTION
## Summary

- inspect through PostgreSQL text casts when validating `TO_DATE` literals against the T-SQL/Fabric `DATE` domain
- reject strict PostgreSQL-to-T-SQL/Fabric transpilation when an aggregate argument contains a subquery that the target would reject with Msg 130
- preserve valid casted date boundaries, dynamic date inputs, scalar subqueries, and aggregates contained inside scalar subqueries
- add mirrored Fabric and T-SQL regression coverage

Fixes #393
Fixes #395

## Validation

- `cargo fmt --all --check`
- complete `fabric_regression`: 150 passed
- complete `tsql_regression`: 149 passed
- focused issue tests pass for both Fabric and T-SQL targets

The broader all-dialects crate command was also attempted locally, but the filesystem ran out of space while linking unrelated test binaries; the two complete affected target suites finished successfully.