### PR TITLE
Fix nested schema validation scopes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   push:
     branches: [main]
-    tags: ['v*']
   pull_request:
     branches: [main]
 

--- a/.github/workflows/python-fork-release.yml
+++ b/.github/workflows/python-fork-release.yml
@@ -1,0 +1,171 @@
+name: Python fork release
+
+on:
+  push:
+    tags: ['python-v*']
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Test Rust library
+        run: cargo test --lib -p polyglot-sql
+
+  wheels-linux:
+    needs: test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          manylinux: '2014'
+          args: --profile python_release --out dist --find-interpreter --manifest-path crates/polyglot-sql-python/Cargo.toml
+          sccache: true
+
+      - name: Smoke test wheel
+        if: matrix.target == 'x86_64'
+        run: |
+          version="${GITHUB_REF_NAME#python-v}"
+          python -m pip install --no-index --find-links dist "polyglot-sql-chio==${version}"
+          python -c "import polyglot_sql; assert polyglot_sql.parse_one('SELECT 1', dialect='postgres')"
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v7
+        with:
+          name: fork-python-wheels-linux-${{ matrix.target }}
+          path: dist
+
+  wheels-macos:
+    needs: test
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-apple-darwin
+            runner: macos-15-intel
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --profile python_release --out dist --find-interpreter --manifest-path crates/polyglot-sql-python/Cargo.toml
+          sccache: true
+
+      - name: Smoke test wheel
+        run: |
+          version="${GITHUB_REF_NAME#python-v}"
+          python -m pip install --no-index --find-links dist "polyglot-sql-chio==${version}"
+          python -c "import polyglot_sql; assert polyglot_sql.parse_one('SELECT 1', dialect='postgres')"
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v7
+        with:
+          name: fork-python-wheels-macos-${{ matrix.target }}
+          path: dist
+
+  wheels-windows:
+    needs: test
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        env:
+          SCCACHE_IGNORE_SERVER_IO_ERROR: '1'
+        with:
+          target: x86_64-pc-windows-msvc
+          args: --profile python_release --out dist --find-interpreter --manifest-path crates/polyglot-sql-python/Cargo.toml
+          sccache: true
+
+      - name: Smoke test wheel
+        shell: pwsh
+        run: |
+          $version = $env:GITHUB_REF_NAME.Substring('python-v'.Length)
+          python -m pip install --no-index --find-links dist "polyglot-sql-chio==$version"
+          python -c "import polyglot_sql; assert polyglot_sql.parse_one('SELECT 1', dialect='postgres')"
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v7
+        with:
+          name: fork-python-wheels-windows-x86_64
+          path: dist
+
+  sdist:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build source distribution
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist --manifest-path crates/polyglot-sql-python/Cargo.toml
+
+      - name: Upload source distribution
+        uses: actions/upload-artifact@v7
+        with:
+          name: fork-python-sdist
+          path: dist
+
+  publish:
+    needs: [wheels-linux, wheels-macos, wheels-windows, sdist]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/polyglot-sql-chio
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: fork-python-*
+          merge-multiple: true
+          path: dist
+
+      - name: Verify artifact versions
+        run: |
+          python - <<'PY'
+          import os
+          from pathlib import Path
+
+          expected = os.environ["GITHUB_REF_NAME"].removeprefix("python-v")
+          artifacts = list(Path("dist").iterdir())
+          if not artifacts:
+              raise SystemExit("No distribution artifacts found")
+          invalid = [
+              path.name
+              for path in artifacts
+              if not path.name.startswith(f"polyglot_sql_chio-{expected}-")
+              and path.name != f"polyglot_sql_chio-{expected}.tar.gz"
+          ]
+          if invalid:
+              raise SystemExit(f"Artifact version mismatch: {invalid}")
+          print(f"Verified {len(artifacts)} artifacts for version {expected}")
+          PY
+
+      - name: Publish Python distribution
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/Makefile
+++ b/Makefile
@@ -395,42 +395,42 @@ bench-python:
 
 # Parse benchmark (core): polyglot-sql (Rust/PyO3) vs sqlglot[c] native extensions via pyperf
 bench-parse:
-	@$(PYTHON_BENCH_BUILD_ENV) uv sync --project tools/bench-compare --reinstall-package polyglot-sql && \
+	@$(PYTHON_BENCH_BUILD_ENV) uv sync --project tools/bench-compare --reinstall-package polyglot-sql-chio && \
 		uv run --project tools/bench-compare python3 tools/bench-compare/bench_parse.py --quiet --core-only
 
 # Parse benchmark (core/quick): faster but less stable timings
 bench-parse-quick:
-	@$(PYTHON_BENCH_BUILD_ENV) uv sync --project tools/bench-compare --reinstall-package polyglot-sql && \
+	@$(PYTHON_BENCH_BUILD_ENV) uv sync --project tools/bench-compare --reinstall-package polyglot-sql-chio && \
 		uv run --project tools/bench-compare python3 tools/bench-compare/bench_parse.py --quiet --core-only --quick
 
 # Parse benchmark (full): include optional third-party parsers when available
 bench-parse-full:
-	@$(PYTHON_BENCH_BUILD_ENV) uv sync --project tools/bench-compare --reinstall-package polyglot-sql && \
+	@$(PYTHON_BENCH_BUILD_ENV) uv sync --project tools/bench-compare --reinstall-package polyglot-sql-chio && \
 		uv run --project tools/bench-compare python3 tools/bench-compare/bench_parse.py --quiet
 
 # Simple parse benchmark (core/quick): polyglot-sql vs sqlglot, median-of-5
 bench-simple-quick:
-	@$(PYTHON_BENCH_BUILD_ENV) uv sync --project tools/bench-compare --reinstall-package polyglot-sql && \
+	@$(PYTHON_BENCH_BUILD_ENV) uv sync --project tools/bench-compare --reinstall-package polyglot-sql-chio && \
 		uv run --project tools/bench-compare python3 tools/bench-compare/bench_simple.py --core-only
 
 # Simple parse benchmark (core): polyglot-sql vs sqlglot, median-of-5
 bench-simple:
-	@$(PYTHON_BENCH_BUILD_ENV) uv sync --project tools/bench-compare --reinstall-package polyglot-sql && \
+	@$(PYTHON_BENCH_BUILD_ENV) uv sync --project tools/bench-compare --reinstall-package polyglot-sql-chio && \
 		uv run --project tools/bench-compare python3 tools/bench-compare/bench_simple.py --core-only
 
 # Simple parse benchmark (full): include optional third-party parsers
 bench-simple-full:
-	@$(PYTHON_BENCH_BUILD_ENV) uv sync --project tools/bench-compare --reinstall-package polyglot-sql && \
+	@$(PYTHON_BENCH_BUILD_ENV) uv sync --project tools/bench-compare --reinstall-package polyglot-sql-chio && \
 		uv run --project tools/bench-compare python3 tools/bench-compare/bench_simple.py
 
 # Transpile benchmark: polyglot-sql (Rust/PyO3) vs sqlglot[c] native extensions via pyperf
 bench-transpile:
-	@$(PYTHON_BENCH_BUILD_ENV) uv sync --project tools/bench-compare --reinstall-package polyglot-sql && \
+	@$(PYTHON_BENCH_BUILD_ENV) uv sync --project tools/bench-compare --reinstall-package polyglot-sql-chio && \
 		uv run --project tools/bench-compare python3 tools/bench-compare/bench_transpile.py --quiet
 
 # Transpile benchmark (quick): faster but less stable timings
 bench-transpile-quick:
-	@$(PYTHON_BENCH_BUILD_ENV) uv sync --project tools/bench-compare --reinstall-package polyglot-sql && \
+	@$(PYTHON_BENCH_BUILD_ENV) uv sync --project tools/bench-compare --reinstall-package polyglot-sql-chio && \
 		uv run --project tools/bench-compare python3 tools/bench-compare/bench_transpile.py --quiet --quick
 
 bench-performance:
@@ -442,7 +442,7 @@ bench-allocations:
 
 bench-python-concurrency:
 	@mkdir -p target/performance
-	@$(PYTHON_BENCH_BUILD_ENV) uv sync --project tools/bench-compare --reinstall-package polyglot-sql
+	@$(PYTHON_BENCH_BUILD_ENV) uv sync --project tools/bench-compare --reinstall-package polyglot-sql-chio
 	@uv run --project tools/bench-compare python3 tools/bench-compare/bench_python_concurrency.py \
 		--output target/performance/python-concurrency.json
 
@@ -502,7 +502,7 @@ develop-python:
 
 # Run Python tests
 test-python:
-	cd crates/polyglot-sql-python && uv sync --group dev --reinstall-package polyglot-sql && uv run --no-sync pytest
+	cd crates/polyglot-sql-python && uv sync --group dev --reinstall-package polyglot-sql-chio && uv run --no-sync pytest
 
 # Build Python wheels (release)
 build-python:
@@ -510,7 +510,7 @@ build-python:
 
 # Type-check Python package/stubs
 typecheck-python:
-	cd crates/polyglot-sql-python && uv sync --group dev --reinstall-package polyglot-sql && uv run --no-sync pyright python/polyglot_sql/
+	cd crates/polyglot-sql-python && uv sync --group dev --reinstall-package polyglot-sql-chio && uv run --no-sync pyright python/polyglot_sql/
 
 # Generate C header via build.rs/cbindgen
 generate-ffi-header:

--- a/crates/polyglot-sql-python/README.md
+++ b/crates/polyglot-sql-python/README.md
@@ -1,13 +1,15 @@
-# polyglot-sql (Python)
+# polyglot-sql-chio (Python)
 
 Rust-powered SQL transpiler for more than 30 SQL dialects.
 
-The `polyglot-sql` Python package exposes an API backed by the Rust `polyglot-sql` engine for fast parse/transpile/generate/format/validate workflows.
+The `polyglot-sql-chio` Python distribution exposes the existing `polyglot_sql` import API backed by the Rust `polyglot-sql` engine for fast parse/transpile/generate/format/validate workflows.
+
+This distribution is maintained as a temporary compatibility fork. Do not install it alongside `polyglot-sql`, because both distributions provide the same `polyglot_sql` package.
 
 ## Installation
 
 ```bash
-pip install polyglot-sql
+pip install polyglot-sql-chio
 ```
 
 ## Quick Start

--- a/crates/polyglot-sql-python/pyproject.toml
+++ b/crates/polyglot-sql-python/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["maturin>=1.7,<2.0"]
 build-backend = "maturin"
 
 [project]
-name = "polyglot-sql"
+name = "polyglot-sql-chio"
 dynamic = ["version"]
 description = "Rust-powered SQL transpiler for more than 30 SQL dialects. Parse, generate, transpile, format, and validate SQL."
 readme = "README.md"
@@ -27,10 +27,10 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/tobilg/polyglot"
+Homepage = "https://github.com/chio-labs/polyglot"
 Documentation = "https://polyglot.gh.tobilg.com"
-Repository = "https://github.com/tobilg/polyglot"
-Issues = "https://github.com/tobilg/polyglot/issues"
+Repository = "https://github.com/chio-labs/polyglot"
+Issues = "https://github.com/chio-labs/polyglot/issues"
 
 [tool.maturin]
 python-source = "python"

--- a/crates/polyglot-sql-python/uv.lock
+++ b/crates/polyglot-sql-python/uv.lock
@@ -103,7 +103,7 @@ wheels = [
 ]
 
 [[package]]
-name = "polyglot-sql"
+name = "polyglot-sql-chio"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/crates/polyglot-sql/src/validation.rs
+++ b/crates/polyglot-sql/src/validation.rs
@@ -2067,19 +2067,59 @@ fn check_query_reference_quality(
     strict: bool,
     relationships: &[DeclaredRelationship],
 ) -> Vec<ValidationError> {
+    let scope = build_scope(stmt);
+    let has_scoped_query = select_for_scope_expression(&scope.expression).is_some()
+        || !scope.cte_scopes.is_empty()
+        || !scope.union_scopes.is_empty()
+        || !scope.derived_table_scopes.is_empty()
+        || !scope.udtf_scopes.is_empty()
+        || !scope.subquery_scopes.is_empty();
+    if has_scoped_query {
+        return check_scope_reference_quality(
+            &scope,
+            schema_map,
+            resolver_schema,
+            strict,
+            relationships,
+        );
+    }
+
     let mut errors = Vec::new();
-
     for node in stmt.dfs() {
-        let Expression::Select(select) = node else {
+        if !matches!(node, Expression::Select(_)) {
             continue;
-        };
+        }
+        let query_scope = build_scope(node);
+        errors.extend(check_scope_reference_quality(
+            &query_scope,
+            schema_map,
+            resolver_schema,
+            strict,
+            relationships,
+        ));
+    }
+    errors
+}
 
-        let select_expr = Expression::Select(select.clone());
+fn check_scope_reference_quality(
+    scope: &crate::scope::Scope,
+    schema_map: &HashMap<String, TableSchemaEntry>,
+    resolver_schema: &MappingSchema,
+    strict: bool,
+    relationships: &[DeclaredRelationship],
+) -> Vec<ValidationError> {
+    let mut errors = Vec::new();
+    if let Some(select) = select_for_scope_expression(&scope.expression) {
+        let select_expr = Expression::Select(Box::new(select.clone()));
         let context = collect_type_check_context(&select_expr, schema_map);
-        let scope = build_scope(&select_expr);
-        let mut resolver = Resolver::new(&scope, resolver_schema, true);
+        let mut resolver = Resolver::new(scope, resolver_schema, true);
 
-        if context.referenced_tables.len() > 1 {
+        let direct_source_count = select
+            .from
+            .as_ref()
+            .map_or(0, |from| from.expressions.len())
+            + select.joins.len();
+        if direct_source_count > 1 {
             let using_columns: HashSet<String> = select
                 .joins
                 .iter()
@@ -2192,6 +2232,51 @@ fn check_query_reference_quality(
         }
     }
 
+    for child in &scope.cte_scopes {
+        errors.extend(check_scope_reference_quality(
+            child,
+            schema_map,
+            resolver_schema,
+            strict,
+            relationships,
+        ));
+    }
+    for child in &scope.union_scopes {
+        errors.extend(check_scope_reference_quality(
+            child,
+            schema_map,
+            resolver_schema,
+            strict,
+            relationships,
+        ));
+    }
+    for child in &scope.derived_table_scopes {
+        errors.extend(check_scope_reference_quality(
+            child,
+            schema_map,
+            resolver_schema,
+            strict,
+            relationships,
+        ));
+    }
+    for child in &scope.udtf_scopes {
+        errors.extend(check_scope_reference_quality(
+            child,
+            schema_map,
+            resolver_schema,
+            strict,
+            relationships,
+        ));
+    }
+    for child in &scope.subquery_scopes {
+        errors.extend(check_scope_reference_quality(
+            child,
+            schema_map,
+            resolver_schema,
+            strict,
+            relationships,
+        ));
+    }
     errors
 }
 
@@ -3325,6 +3410,7 @@ fn source_display_name(scope: &crate::scope::Scope, source_name: &str) -> String
 fn validate_select_columns_with_schema(
     select: &crate::expressions::Select,
     scope: &crate::scope::Scope,
+    outer_sources: &HashMap<String, crate::scope::SourceInfo>,
     schema_map: &HashMap<String, TableSchemaEntry>,
     resolver_schema: &MappingSchema,
     strict: bool,
@@ -3403,6 +3489,21 @@ fn validate_select_columns_with_schema(
             .collect();
 
         if !matching_sources.is_empty() {
+            continue;
+        }
+
+        let mut outer_scope = normalized_scope.clone();
+        outer_scope.sources = outer_sources.clone();
+        let mut outer_resolver = Resolver::new(&outer_scope, resolver_schema, true);
+        let matches_outer_source = outer_scope.sources.keys().any(|source_name| {
+            outer_resolver
+                .get_source_columns(source_name)
+                .ok()
+                .is_some_and(|columns| {
+                    !columns.is_empty() && source_has_column(&columns, &col_name)
+                })
+        });
+        if matches_outer_source {
             continue;
         }
 
@@ -3495,6 +3596,7 @@ fn validate_scope_columns_with_schema(
     strict: bool,
 ) -> Vec<ValidationError> {
     let mut errors = Vec::new();
+    let empty_sources = HashMap::new();
     let mut effective_scope = scope.clone();
     if scope.can_be_correlated {
         for node in walk_in_scope(&scope.expression, false) {
@@ -3520,6 +3622,7 @@ fn validate_scope_columns_with_schema(
         errors.extend(validate_select_columns_with_schema(
             select,
             &effective_scope,
+            outer_sources,
             schema_map,
             resolver_schema,
             strict,
@@ -3529,7 +3632,7 @@ fn validate_scope_columns_with_schema(
     for child in &scope.cte_scopes {
         errors.extend(validate_scope_columns_with_schema(
             child,
-            &HashMap::new(),
+            &empty_sources,
             schema_map,
             resolver_schema,
             strict,
@@ -3547,7 +3650,11 @@ fn validate_scope_columns_with_schema(
     for child in &scope.derived_table_scopes {
         errors.extend(validate_scope_columns_with_schema(
             child,
-            &HashMap::new(),
+            if child.can_be_correlated {
+                outer_sources
+            } else {
+                &empty_sources
+            },
             schema_map,
             resolver_schema,
             strict,
@@ -3556,7 +3663,11 @@ fn validate_scope_columns_with_schema(
     for child in &scope.udtf_scopes {
         errors.extend(validate_scope_columns_with_schema(
             child,
-            &HashMap::new(),
+            if child.can_be_correlated {
+                outer_sources
+            } else {
+                &empty_sources
+            },
             schema_map,
             resolver_schema,
             strict,

--- a/crates/polyglot-sql/src/validation.rs
+++ b/crates/polyglot-sql/src/validation.rs
@@ -2087,8 +2087,8 @@ fn check_query_reference_quality(
                 .collect();
 
             let mut seen = HashSet::new();
-            for column_expr in select_expr
-                .find_all(|e| matches!(e, Expression::Column(col) if col.table.is_none()))
+            for column_expr in walk_in_scope(&select_expr, false)
+                .filter(|e| matches!(e, Expression::Column(col) if col.table.is_none()))
             {
                 let Expression::Column(column) = column_expr else {
                     continue;
@@ -3324,6 +3324,7 @@ fn source_display_name(scope: &crate::scope::Scope, source_name: &str) -> String
 
 fn validate_select_columns_with_schema(
     select: &crate::expressions::Select,
+    scope: &crate::scope::Scope,
     schema_map: &HashMap<String, TableSchemaEntry>,
     resolver_schema: &MappingSchema,
     strict: bool,
@@ -3332,9 +3333,10 @@ fn validate_select_columns_with_schema(
     let mut normalized_select = select.clone();
     let _ = normalize_dotted_columns(&mut normalized_select, resolver_schema, true);
     let select_expr = Expression::Select(Box::new(normalized_select));
-    let scope = build_scope(&select_expr);
-    let mut resolver = Resolver::new(&scope, resolver_schema, true);
-    let source_names: Vec<String> = scope.sources.keys().cloned().collect();
+    let mut normalized_scope = scope.clone();
+    normalized_scope.expression = select_expr.clone();
+    let mut resolver = Resolver::new(&normalized_scope, resolver_schema, true);
+    let source_names: Vec<String> = normalized_scope.sources.keys().cloned().collect();
 
     for node in walk_in_scope(&select_expr, false) {
         let Expression::Column(column) = node else {
@@ -3347,7 +3349,8 @@ fn validate_select_columns_with_schema(
         }
 
         if let Some(table) = &column.table {
-            let Some(source_name) = resolve_scope_source_name(&scope, &table.name) else {
+            let Some(source_name) = resolve_scope_source_name(&normalized_scope, &table.name)
+            else {
                 // The table qualifier is not a declared alias or source in this scope
                 errors.push(if strict {
                     ValidationError::error(
@@ -3371,7 +3374,7 @@ fn validate_select_columns_with_schema(
 
             if let Ok(columns) = resolver.get_source_columns(&source_name) {
                 if !columns.is_empty() && !source_has_column(&columns, &col_name) {
-                    let table_name = source_display_name(&scope, &source_name);
+                    let table_name = source_display_name(&normalized_scope, &source_name);
                     errors.push(if strict {
                         ValidationError::error(
                             format!("Unknown column '{}' in table '{}'", col_name, table_name),
@@ -3415,7 +3418,7 @@ fn validate_select_columns_with_schema(
             .collect();
 
         if known_sources.len() == 1 {
-            let table_name = source_display_name(&scope, &known_sources[0]);
+            let table_name = source_display_name(&normalized_scope, &known_sources[0]);
             errors.push(if strict {
                 ValidationError::error(
                     format!("Unknown column '{}' in table '{}'", col_name, table_name),
@@ -3468,6 +3471,110 @@ fn validate_select_columns_with_schema(
     errors
 }
 
+fn select_for_scope_expression(expression: &Expression) -> Option<&crate::expressions::Select> {
+    match expression {
+        Expression::Select(select) => Some(select),
+        Expression::Cte(cte) => select_for_scope_expression(&cte.this),
+        Expression::Subquery(subquery) => select_for_scope_expression(&subquery.this),
+        Expression::Alias(alias) => select_for_scope_expression(&alias.this),
+        Expression::Paren(paren) => select_for_scope_expression(&paren.this),
+        Expression::CreateTable(create) => create
+            .as_select
+            .as_ref()
+            .and_then(select_for_scope_expression),
+        Expression::Prepare(prepare) => select_for_scope_expression(&prepare.statement),
+        _ => None,
+    }
+}
+
+fn validate_scope_columns_with_schema(
+    scope: &crate::scope::Scope,
+    outer_sources: &HashMap<String, crate::scope::SourceInfo>,
+    schema_map: &HashMap<String, TableSchemaEntry>,
+    resolver_schema: &MappingSchema,
+    strict: bool,
+) -> Vec<ValidationError> {
+    let mut errors = Vec::new();
+    let mut effective_scope = scope.clone();
+    if scope.can_be_correlated {
+        for node in walk_in_scope(&scope.expression, false) {
+            let Expression::Column(column) = node else {
+                continue;
+            };
+            let Some(table) = &column.table else {
+                continue;
+            };
+            if resolve_scope_source_name(&effective_scope, &table.name).is_some() {
+                continue;
+            }
+            if let Some((name, source)) = outer_sources
+                .iter()
+                .find(|(name, _)| name.eq_ignore_ascii_case(&table.name))
+            {
+                effective_scope.sources.insert(name.clone(), source.clone());
+            }
+        }
+    }
+
+    if let Some(select) = select_for_scope_expression(&scope.expression) {
+        errors.extend(validate_select_columns_with_schema(
+            select,
+            &effective_scope,
+            schema_map,
+            resolver_schema,
+            strict,
+        ));
+    }
+
+    for child in &scope.cte_scopes {
+        errors.extend(validate_scope_columns_with_schema(
+            child,
+            &HashMap::new(),
+            schema_map,
+            resolver_schema,
+            strict,
+        ));
+    }
+    for child in &scope.union_scopes {
+        errors.extend(validate_scope_columns_with_schema(
+            child,
+            outer_sources,
+            schema_map,
+            resolver_schema,
+            strict,
+        ));
+    }
+    for child in &scope.derived_table_scopes {
+        errors.extend(validate_scope_columns_with_schema(
+            child,
+            &HashMap::new(),
+            schema_map,
+            resolver_schema,
+            strict,
+        ));
+    }
+    for child in &scope.udtf_scopes {
+        errors.extend(validate_scope_columns_with_schema(
+            child,
+            &HashMap::new(),
+            schema_map,
+            resolver_schema,
+            strict,
+        ));
+    }
+    for child in &scope.subquery_scopes {
+        errors.extend(validate_scope_columns_with_schema(
+            child,
+            &effective_scope.sources,
+            schema_map,
+            resolver_schema,
+            strict,
+        ));
+    }
+
+    errors
+}
+
 fn validate_statement_with_schema(
     stmt: &Expression,
     schema_map: &HashMap<String, TableSchemaEntry>,
@@ -3514,16 +3621,38 @@ fn validate_statement_with_schema(
         }
     }
 
-    for node in stmt.dfs() {
-        let Expression::Select(select) = node else {
-            continue;
-        };
-        errors.extend(validate_select_columns_with_schema(
-            select,
+    let scope = build_scope(stmt);
+    let has_scoped_query = select_for_scope_expression(&scope.expression).is_some()
+        || !scope.cte_scopes.is_empty()
+        || !scope.union_scopes.is_empty()
+        || !scope.derived_table_scopes.is_empty()
+        || !scope.udtf_scopes.is_empty()
+        || !scope.subquery_scopes.is_empty();
+    if has_scoped_query {
+        errors.extend(validate_scope_columns_with_schema(
+            &scope,
+            &HashMap::new(),
             schema_map,
             resolver_schema,
             strict,
         ));
+    } else {
+        // Preserve validation for query bodies in statement wrappers that the scope builder
+        // does not model yet, such as INSERT ... SELECT.
+        for node in stmt.dfs() {
+            let Expression::Select(select) = node else {
+                continue;
+            };
+            let select_expression = Expression::Select(select.clone());
+            let select_scope = build_scope(&select_expression);
+            errors.extend(validate_scope_columns_with_schema(
+                &select_scope,
+                &HashMap::new(),
+                schema_map,
+                resolver_schema,
+                strict,
+            ));
+        }
     }
 
     errors

--- a/crates/polyglot-sql/src/validation.rs
+++ b/crates/polyglot-sql/src/validation.rs
@@ -3495,15 +3495,39 @@ fn validate_select_columns_with_schema(
         let mut outer_scope = normalized_scope.clone();
         outer_scope.sources = outer_sources.clone();
         let mut outer_resolver = Resolver::new(&outer_scope, resolver_schema, true);
-        let matches_outer_source = outer_scope.sources.keys().any(|source_name| {
-            outer_resolver
-                .get_source_columns(source_name)
-                .ok()
-                .is_some_and(|columns| {
-                    !columns.is_empty() && source_has_column(&columns, &col_name)
-                })
-        });
-        if matches_outer_source {
+        let matching_outer_source_count = outer_scope
+            .sources
+            .keys()
+            .filter(|source_name| {
+                outer_resolver
+                    .get_source_columns(source_name)
+                    .ok()
+                    .is_some_and(|columns| {
+                        !columns.is_empty() && source_has_column(&columns, &col_name)
+                    })
+            })
+            .count();
+        if matching_outer_source_count == 1 {
+            continue;
+        }
+        if matching_outer_source_count > 1 {
+            errors.push(if strict {
+                ValidationError::error(
+                    format!(
+                        "Ambiguous unqualified column '{}' found in {} outer sources",
+                        col_name, matching_outer_source_count
+                    ),
+                    validation_codes::E_AMBIGUOUS_COLUMN_REFERENCE,
+                )
+            } else {
+                ValidationError::warning(
+                    format!(
+                        "Ambiguous unqualified column '{}' found in {} outer sources",
+                        col_name, matching_outer_source_count
+                    ),
+                    validation_codes::W_WEAK_REFERENCE_INTEGRITY,
+                )
+            });
             continue;
         }
 

--- a/crates/polyglot-sql/src/validation/tests.rs
+++ b/crates/polyglot-sql/src/validation/tests.rs
@@ -508,6 +508,28 @@ fn test_validate_with_schema_nested_scalar_subquery_resolves_outer_column() {
 }
 
 #[test]
+fn test_validate_with_schema_ambiguous_outer_column_stays_invalid() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    let result = validate_with_schema(
+        "SELECT users.id FROM users JOIN orders ON users.id = orders.user_id \
+         WHERE EXISTS (SELECT 1 WHERE id > 0)",
+        DialectType::Generic,
+        &schema,
+        &opts,
+    );
+
+    assert!(!result.valid);
+    assert!(result.errors.iter().any(|error| {
+        error.code == validation_codes::E_AMBIGUOUS_COLUMN_REFERENCE
+            && error.message.contains("outer sources")
+    }));
+}
+
+#[test]
 fn test_validate_with_schema_unknown_column_after_cte_projection_stays_invalid() {
     let schema = base_schema();
     let opts = SchemaValidationOptions {

--- a/crates/polyglot-sql/src/validation/tests.rs
+++ b/crates/polyglot-sql/src/validation/tests.rs
@@ -181,6 +181,139 @@ fn test_validate_with_schema_known_table_column() {
 }
 
 #[test]
+fn test_validate_with_schema_qualified_cte_column_is_not_ambiguous() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    let result = validate_with_schema(
+        "WITH selected_users AS (SELECT id FROM users), \
+         selected_orders AS (SELECT id FROM orders) \
+         SELECT selected_users.id FROM selected_users \
+         JOIN selected_orders ON selected_users.id = selected_orders.id",
+        DialectType::Generic,
+        &schema,
+        &opts,
+    );
+
+    assert!(result.valid, "{:#?}", result.errors);
+}
+
+#[test]
+fn test_validate_with_schema_correlated_subquery_resolves_outer_alias() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    let result = validate_with_schema(
+        "SELECT outer_users.id FROM users outer_users \
+         WHERE EXISTS (SELECT 1 FROM orders inner_orders \
+         WHERE inner_orders.user_id = outer_users.id)",
+        DialectType::Generic,
+        &schema,
+        &opts,
+    );
+
+    assert!(result.valid, "{:#?}", result.errors);
+}
+
+#[test]
+fn test_validate_with_schema_correlated_subquery_prefers_inner_unqualified_column() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    let result = validate_with_schema(
+        "SELECT outer_users.id FROM users outer_users \
+         WHERE EXISTS (SELECT 1 FROM orders inner_orders \
+         WHERE id = outer_users.id)",
+        DialectType::Generic,
+        &schema,
+        &opts,
+    );
+
+    assert!(result.valid, "{:#?}", result.errors);
+}
+
+#[test]
+fn test_validate_with_schema_subsequent_cte_resolves_prior_projection() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    let result = validate_with_schema(
+        "WITH derived AS (SELECT total AS derived_total FROM orders), \
+         next AS (SELECT derived_total FROM derived) \
+         SELECT derived_total FROM next",
+        DialectType::Generic,
+        &schema,
+        &opts,
+    );
+
+    assert!(result.valid, "{:#?}", result.errors);
+}
+
+#[test]
+fn test_validate_with_schema_window_resolves_prior_cte_projection() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    let result = validate_with_schema(
+        "WITH scored AS (SELECT user_id, total AS order_total FROM orders), \
+         ranked AS (SELECT user_id, ROW_NUMBER() OVER ( \
+         PARTITION BY user_id ORDER BY order_total DESC) AS row_number FROM scored) \
+         SELECT user_id FROM ranked",
+        DialectType::Generic,
+        &schema,
+        &opts,
+    );
+
+    assert!(result.valid, "{:#?}", result.errors);
+}
+
+#[test]
+fn test_validate_with_schema_unknown_column_in_derived_table() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions::default();
+    let result = validate_with_schema(
+        "SELECT selected.id FROM (SELECT missing FROM users) selected",
+        DialectType::Generic,
+        &schema,
+        &opts,
+    );
+
+    assert!(!result.valid);
+    assert!(result
+        .errors
+        .iter()
+        .any(|error| error.code == validation_codes::E_UNKNOWN_COLUMN));
+}
+
+#[test]
+fn test_validate_with_schema_unknown_column_in_insert_query() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions::default();
+    let result = validate_with_schema(
+        "INSERT INTO users (id) SELECT missing FROM orders",
+        DialectType::Generic,
+        &schema,
+        &opts,
+    );
+
+    assert!(!result.valid);
+    assert!(result
+        .errors
+        .iter()
+        .any(|error| error.code == validation_codes::E_UNKNOWN_COLUMN));
+}
+
+#[test]
 fn test_validate_with_schema_unknown_table() {
     let schema = base_schema();
     let opts = SchemaValidationOptions::default();

--- a/crates/polyglot-sql/src/validation/tests.rs
+++ b/crates/polyglot-sql/src/validation/tests.rs
@@ -166,6 +166,18 @@ fn test_function_catalog() -> Arc<HashMapFunctionCatalog> {
     Arc::new(catalog)
 }
 
+fn schema_validation_dialects() -> [DialectType; 7] {
+    [
+        DialectType::Generic,
+        DialectType::Snowflake,
+        DialectType::DuckDB,
+        DialectType::BigQuery,
+        DialectType::Databricks,
+        DialectType::PostgreSQL,
+        DialectType::TSQL,
+    ]
+}
+
 #[test]
 fn test_validate_with_schema_known_table_column() {
     let schema = base_schema();
@@ -187,17 +199,19 @@ fn test_validate_with_schema_qualified_cte_column_is_not_ambiguous() {
         check_references: true,
         ..Default::default()
     };
-    let result = validate_with_schema(
-        "WITH selected_users AS (SELECT id FROM users), \
-         selected_orders AS (SELECT id FROM orders) \
-         SELECT selected_users.id FROM selected_users \
-         JOIN selected_orders ON selected_users.id = selected_orders.id",
-        DialectType::Generic,
-        &schema,
-        &opts,
-    );
+    for dialect in schema_validation_dialects() {
+        let result = validate_with_schema(
+            "WITH selected_users AS (SELECT id FROM users), \
+             selected_orders AS (SELECT id FROM orders) \
+             SELECT selected_users.id FROM selected_users \
+             JOIN selected_orders ON selected_users.id = selected_orders.id",
+            dialect,
+            &schema,
+            &opts,
+        );
 
-    assert!(result.valid, "{:#?}", result.errors);
+        assert!(result.valid, "{dialect}: {:#?}", result.errors);
+    }
 }
 
 #[test]
@@ -207,16 +221,18 @@ fn test_validate_with_schema_correlated_subquery_resolves_outer_alias() {
         check_references: true,
         ..Default::default()
     };
-    let result = validate_with_schema(
-        "SELECT outer_users.id FROM users outer_users \
-         WHERE EXISTS (SELECT 1 FROM orders inner_orders \
-         WHERE inner_orders.user_id = outer_users.id)",
-        DialectType::Generic,
-        &schema,
-        &opts,
-    );
+    for dialect in schema_validation_dialects() {
+        let result = validate_with_schema(
+            "SELECT outer_users.id FROM users outer_users \
+             WHERE EXISTS (SELECT 1 FROM orders inner_orders \
+             WHERE inner_orders.user_id = outer_users.id)",
+            dialect,
+            &schema,
+            &opts,
+        );
 
-    assert!(result.valid, "{:#?}", result.errors);
+        assert!(result.valid, "{dialect}: {:#?}", result.errors);
+    }
 }
 
 #[test]
@@ -226,16 +242,18 @@ fn test_validate_with_schema_correlated_subquery_prefers_inner_unqualified_colum
         check_references: true,
         ..Default::default()
     };
-    let result = validate_with_schema(
-        "SELECT outer_users.id FROM users outer_users \
-         WHERE EXISTS (SELECT 1 FROM orders inner_orders \
-         WHERE id = outer_users.id)",
-        DialectType::Generic,
-        &schema,
-        &opts,
-    );
+    for dialect in schema_validation_dialects() {
+        let result = validate_with_schema(
+            "SELECT outer_users.id FROM users outer_users \
+             WHERE EXISTS (SELECT 1 FROM orders inner_orders \
+             WHERE id = outer_users.id)",
+            dialect,
+            &schema,
+            &opts,
+        );
 
-    assert!(result.valid, "{:#?}", result.errors);
+        assert!(result.valid, "{dialect}: {:#?}", result.errors);
+    }
 }
 
 #[test]
@@ -245,16 +263,18 @@ fn test_validate_with_schema_subsequent_cte_resolves_prior_projection() {
         check_references: true,
         ..Default::default()
     };
-    let result = validate_with_schema(
-        "WITH derived AS (SELECT total AS derived_total FROM orders), \
-         next AS (SELECT derived_total FROM derived) \
-         SELECT derived_total FROM next",
-        DialectType::Generic,
-        &schema,
-        &opts,
-    );
+    for dialect in schema_validation_dialects() {
+        let result = validate_with_schema(
+            "WITH derived AS (SELECT total AS derived_total FROM orders), \
+             next AS (SELECT derived_total FROM derived) \
+             SELECT derived_total FROM next",
+            dialect,
+            &schema,
+            &opts,
+        );
 
-    assert!(result.valid, "{:#?}", result.errors);
+        assert!(result.valid, "{dialect}: {:#?}", result.errors);
+    }
 }
 
 #[test]
@@ -264,17 +284,19 @@ fn test_validate_with_schema_window_resolves_prior_cte_projection() {
         check_references: true,
         ..Default::default()
     };
-    let result = validate_with_schema(
-        "WITH scored AS (SELECT user_id, total AS order_total FROM orders), \
-         ranked AS (SELECT user_id, ROW_NUMBER() OVER ( \
-         PARTITION BY user_id ORDER BY order_total DESC) AS row_number FROM scored) \
-         SELECT user_id FROM ranked",
-        DialectType::Generic,
-        &schema,
-        &opts,
-    );
+    for dialect in schema_validation_dialects() {
+        let result = validate_with_schema(
+            "WITH scored AS (SELECT user_id, total AS order_total FROM orders), \
+             ranked AS (SELECT user_id, ROW_NUMBER() OVER ( \
+             PARTITION BY user_id ORDER BY order_total DESC) AS row_number FROM scored) \
+             SELECT user_id FROM ranked",
+            dialect,
+            &schema,
+            &opts,
+        );
 
-    assert!(result.valid, "{:#?}", result.errors);
+        assert!(result.valid, "{dialect}: {:#?}", result.errors);
+    }
 }
 
 #[test]

--- a/crates/polyglot-sql/src/validation/tests.rs
+++ b/crates/polyglot-sql/src/validation/tests.rs
@@ -300,6 +300,239 @@ fn test_validate_with_schema_window_resolves_prior_cte_projection() {
 }
 
 #[test]
+fn test_validate_with_schema_joined_cte_projection_preserves_scope() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    for dialect in schema_validation_dialects() {
+        let result = validate_with_schema(
+            "WITH selected_users AS (SELECT id, name FROM users), \
+             selected_orders AS (SELECT id, user_id, total FROM orders), \
+             combined AS (SELECT selected_users.*, selected_orders.total \
+             FROM selected_users JOIN selected_orders \
+             ON selected_users.id = selected_orders.user_id) \
+             SELECT id, name, total FROM combined",
+            dialect,
+            &schema,
+            &opts,
+        );
+
+        assert!(result.valid, "{dialect}: {:#?}", result.errors);
+    }
+}
+
+#[test]
+fn test_validate_with_schema_chained_star_projection_preserves_aliases() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    for dialect in schema_validation_dialects() {
+        let result = validate_with_schema(
+            "WITH totals AS (SELECT user_id, total AS order_total FROM orders), \
+             copied AS (SELECT * FROM totals), \
+             scored AS (SELECT *, order_total + 1 AS adjusted_total FROM copied) \
+             SELECT user_id, order_total, adjusted_total FROM scored",
+            dialect,
+            &schema,
+            &opts,
+        );
+
+        assert!(result.valid, "{dialect}: {:#?}", result.errors);
+    }
+}
+
+#[test]
+fn test_validate_with_schema_snowflake_qualify_resolves_projection_columns() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    let result = validate_with_schema(
+        "WITH ranked AS (SELECT user_id, total, \
+         ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY total DESC) AS row_number \
+         FROM orders QUALIFY row_number = 1) \
+         SELECT user_id, total FROM ranked",
+        DialectType::Snowflake,
+        &schema,
+        &opts,
+    );
+
+    assert!(result.valid, "{:#?}", result.errors);
+}
+
+#[test]
+fn test_validate_with_schema_snowflake_union_by_name_preserves_projection() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    let result = validate_with_schema(
+        "WITH records AS (SELECT id, name FROM users \
+         UNION ALL BY NAME SELECT id, CAST(total AS VARCHAR) AS name FROM orders) \
+         SELECT id, name FROM records",
+        DialectType::Snowflake,
+        &schema,
+        &opts,
+    );
+
+    assert!(result.valid, "{:#?}", result.errors);
+}
+
+#[test]
+fn test_validate_with_schema_snowflake_join_using_resolves_cte_column() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    let result = validate_with_schema(
+        "WITH selected_users AS (SELECT id, name FROM users) \
+         SELECT orders.id, selected_users.name FROM orders \
+         INNER JOIN selected_users USING (id)",
+        DialectType::Snowflake,
+        &schema,
+        &opts,
+    );
+
+    assert!(result.valid, "{:#?}", result.errors);
+}
+
+#[test]
+fn test_validate_with_schema_snowflake_join_using_cte_from_same_table() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    let result = validate_with_schema(
+        "WITH selected_users AS (SELECT id FROM users WHERE age >= 18), \
+         combined AS (SELECT users.* FROM users \
+         INNER JOIN selected_users USING (id)) \
+         SELECT id, name FROM combined",
+        DialectType::Snowflake,
+        &schema,
+        &opts,
+    );
+
+    assert!(result.valid, "{:#?}", result.errors);
+}
+
+#[test]
+fn test_validate_with_schema_snowflake_nested_qualify_resolves_cte_projection() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    let result = validate_with_schema(
+        "WITH customer_orders AS (SELECT user_id, id AS order_id, total FROM orders), \
+         deduplicated AS (SELECT * FROM (SELECT user_id, order_id, total \
+         FROM customer_orders QUALIFY ROW_NUMBER() OVER (PARTITION BY user_id \
+         ORDER BY order_id) = 1)) SELECT user_id, order_id, total FROM deduplicated",
+        DialectType::Snowflake,
+        &schema,
+        &opts,
+    );
+
+    assert!(result.valid, "{:#?}", result.errors);
+}
+
+#[test]
+fn test_validate_with_schema_snowflake_deep_nested_qualify_resolves_cte_projection() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    let result = validate_with_schema(
+        "WITH base AS (SELECT id AS user_id, name, age FROM users), \
+         flags AS (SELECT user_id FROM (SELECT user_id FROM ( \
+         SELECT user_id, name, age FROM base \
+         QUALIFY ROW_NUMBER() OVER (PARTITION BY user_id, name ORDER BY age) = 1))) \
+         SELECT user_id FROM flags",
+        DialectType::Snowflake,
+        &schema,
+        &opts,
+    );
+
+    assert!(result.valid, "{:#?}", result.errors);
+}
+
+#[test]
+fn test_validate_with_schema_deep_star_chain_preserves_computed_alias() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    for dialect in schema_validation_dialects() {
+        let result = validate_with_schema(
+            "WITH base AS (SELECT user_id, total FROM orders), \
+             first_copy AS (SELECT *, total + 1 AS adjusted_total FROM base), \
+             second_copy AS (SELECT * FROM first_copy), \
+             third_copy AS (SELECT * FROM second_copy), \
+             fourth_copy AS (SELECT *, adjusted_total * 2 AS score FROM third_copy) \
+             SELECT user_id, adjusted_total, score FROM fourth_copy",
+            dialect,
+            &schema,
+            &opts,
+        );
+
+        assert!(result.valid, "{dialect}: {:#?}", result.errors);
+    }
+}
+
+#[test]
+fn test_validate_with_schema_nested_scalar_subquery_resolves_outer_column() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    for dialect in schema_validation_dialects() {
+        let result = validate_with_schema(
+            "WITH metrics AS (SELECT user_id, total AS score FROM orders), \
+             adjusted AS (SELECT score, CASE WHEN score IS NULL THEN NULL ELSE ( \
+             SELECT adjusted_score FROM (SELECT score + 1 AS adjusted_score)) END AS result \
+             FROM metrics) SELECT score, result FROM adjusted",
+            dialect,
+            &schema,
+            &opts,
+        );
+
+        assert!(result.valid, "{dialect}: {:#?}", result.errors);
+    }
+}
+
+#[test]
+fn test_validate_with_schema_unknown_column_after_cte_projection_stays_invalid() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    let result = validate_with_schema(
+        "WITH selected_users AS (SELECT id, name FROM users) \
+         SELECT missing_column FROM selected_users",
+        DialectType::Generic,
+        &schema,
+        &opts,
+    );
+
+    assert!(!result.valid);
+    assert!(result
+        .errors
+        .iter()
+        .any(|error| error.code == validation_codes::E_UNKNOWN_COLUMN));
+}
+
+#[test]
 fn test_validate_with_schema_unknown_column_in_derived_table() {
     let schema = base_schema();
     let opts = SchemaValidationOptions::default();

--- a/tools/bench-compare/bench_transpile.py
+++ b/tools/bench-compare/bench_transpile.py
@@ -10,7 +10,7 @@ Run via make from the project root:
 
 Or directly:
 
-    uv sync --project tools/bench-compare --reinstall-package polyglot-sql
+    uv sync --project tools/bench-compare --reinstall-package polyglot-sql-chio
     uv run --project tools/bench-compare python3 tools/bench-compare/bench_transpile.py --quiet
     uv run --project tools/bench-compare python3 tools/bench-compare/bench_transpile.py --quiet --quick
 """

--- a/tools/bench-compare/pyproject.toml
+++ b/tools/bench-compare/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 description = "Benchmark environment for parser performance comparisons."
 requires-python = ">=3.9"
 dependencies = [
-    "polyglot-sql",
+    "polyglot-sql-chio",
     "moz-sql-parser>=4.40.0",
     "pyperf>=2.7.0",
     "sqloxide>=0.1.56; python_version < '3.14'",
@@ -15,4 +15,4 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-polyglot-sql = { path = "../../crates/polyglot-sql-python", editable = true }
+polyglot-sql-chio = { path = "../../crates/polyglot-sql-python", editable = true }

--- a/tools/bench-compare/uv.lock
+++ b/tools/bench-compare/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.10'",
@@ -38,7 +38,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
 wheels = [
@@ -53,7 +53,7 @@ resolution-markers = [
     "python_full_version >= '3.10'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
 wheels = [
@@ -77,10 +77,10 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "chardet", version = "5.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "jinja2", marker = "python_full_version < '3.10'" },
-    { name = "pluggy", marker = "python_full_version < '3.10'" },
-    { name = "pygments", marker = "python_full_version < '3.10'" },
+    { name = "chardet", version = "5.2.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "jinja2" },
+    { name = "pluggy" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/f4/5d876c7d262bb40108ac6109c426ee97e49d975e8623031ae5e1d69f2d1d/diff_cover-10.0.0.tar.gz", hash = "sha256:92ead026726055bf4c1a90cd7ff83544049d467840e07c66289a4351126dbe25", size = 100934, upload-time = "2025-12-10T02:50:29.791Z" }
 wheels = [
@@ -95,10 +95,10 @@ resolution-markers = [
     "python_full_version >= '3.10'",
 ]
 dependencies = [
-    { name = "chardet", version = "6.0.0.post1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "jinja2", marker = "python_full_version >= '3.10'" },
-    { name = "pluggy", marker = "python_full_version >= '3.10'" },
-    { name = "pygments", marker = "python_full_version >= '3.10'" },
+    { name = "chardet", version = "6.0.0.post1", source = { registry = "https://pypi.org/simple" } },
+    { name = "jinja2" },
+    { name = "pluggy" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/99/b4/eee71d1e338bc1f9bd3539b46b70e303dac061324b759c9a80fa3c96d90d/diff_cover-10.2.0.tar.gz", hash = "sha256:61bf83025f10510c76ef6a5820680cf61b9b974e8f81de70c57ac926fa63872a", size = 102473, upload-time = "2026-01-09T01:59:07.605Z" }
 wheels = [
@@ -110,7 +110,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -364,7 +364,7 @@ version = "0.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "moz-sql-parser" },
-    { name = "polyglot-sql" },
+    { name = "polyglot-sql-chio" },
     { name = "pyperf" },
     { name = "sqlfluff" },
     { name = "sqlglot", extra = ["c"] },
@@ -376,7 +376,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "moz-sql-parser", specifier = ">=4.40.0" },
-    { name = "polyglot-sql", editable = "../../crates/polyglot-sql-python" },
+    { name = "polyglot-sql-chio", editable = "../../crates/polyglot-sql-python" },
     { name = "pyperf", specifier = ">=2.7.0" },
     { name = "sqlfluff", specifier = ">=3.4.2" },
     { name = "sqlglot", extras = ["c"], specifier = "==30.12.0" },
@@ -386,7 +386,7 @@ requires-dist = [
 ]
 
 [[package]]
-name = "polyglot-sql"
+name = "polyglot-sql-chio"
 source = { editable = "../../crates/polyglot-sql-python" }
 
 [package.metadata]
@@ -455,13 +455,13 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
-    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "packaging", marker = "python_full_version < '3.10'" },
-    { name = "pluggy", marker = "python_full_version < '3.10'" },
-    { name = "pygments", marker = "python_full_version < '3.10'" },
-    { name = "tomli", marker = "python_full_version < '3.10'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
@@ -476,13 +476,13 @@ resolution-markers = [
     "python_full_version >= '3.10'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
-    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "packaging", marker = "python_full_version >= '3.10'" },
-    { name = "pluggy", marker = "python_full_version >= '3.10'" },
-    { name = "pygments", marker = "python_full_version >= '3.10'" },
-    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
@@ -876,7 +876,7 @@ name = "sqlglotc"
 version = "30.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sqlglot", marker = "python_full_version >= '3.10'" },
+    { name = "sqlglot" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/05/bdb3c3433f19324ed3499bc51adb6db934f77d947ed1c624554523b22966/sqlglotc-30.12.0.tar.gz", hash = "sha256:7c4c9c7d76026b75f64a6682faf84cf5145e3304190c07807b86962d8d535f74", size = 491114, upload-time = "2026-06-26T14:08:47.042Z" }
 wheels = [


### PR DESCRIPTION
## Summary

`validate_with_schema` now validates nested queries using the hierarchical scopes already produced by `build_scope` instead of rebuilding every nested `SELECT` as an isolated root.

This change:

- prevents columns inside CTE bodies from being checked against outer-query sources
- preserves projected columns from prior sibling CTEs
- resolves explicitly qualified outer aliases in correlated subqueries
- keeps inner unqualified-column resolution local
- preserves validation in derived tables and statement wrappers such as `INSERT ... SELECT`
- covers the scope regressions across Generic, Snowflake, DuckDB, BigQuery, Databricks, PostgreSQL, and TSQL

Fixes #441.
Fixes #442.

## Verification

- `cargo test -p polyglot-sql validation::tests` (50 passed)
- `cargo test --lib -p polyglot-sql` (1181 passed)
- `make lint-rust`
- full fork CI, including Rust, Python, FFI, WASM, Go, and SDK jobs
