### PR TITLE
Fix nested schema validation scope boundaries

### DIFF
--- a/crates/polyglot-sql/src/validation.rs
+++ b/crates/polyglot-sql/src/validation.rs
@@ -2067,19 +2067,59 @@ fn check_query_reference_quality(
     strict: bool,
     relationships: &[DeclaredRelationship],
 ) -> Vec<ValidationError> {
+    let scope = build_scope(stmt);
+    let has_scoped_query = select_for_scope_expression(&scope.expression).is_some()
+        || !scope.cte_scopes.is_empty()
+        || !scope.union_scopes.is_empty()
+        || !scope.derived_table_scopes.is_empty()
+        || !scope.udtf_scopes.is_empty()
+        || !scope.subquery_scopes.is_empty();
+    if has_scoped_query {
+        return check_scope_reference_quality(
+            &scope,
+            schema_map,
+            resolver_schema,
+            strict,
+            relationships,
+        );
+    }
+
     let mut errors = Vec::new();
-
     for node in stmt.dfs() {
-        let Expression::Select(select) = node else {
+        if !matches!(node, Expression::Select(_)) {
             continue;
-        };
+        }
+        let query_scope = build_scope(node);
+        errors.extend(check_scope_reference_quality(
+            &query_scope,
+            schema_map,
+            resolver_schema,
+            strict,
+            relationships,
+        ));
+    }
+    errors
+}
 
-        let select_expr = Expression::Select(select.clone());
+fn check_scope_reference_quality(
+    scope: &crate::scope::Scope,
+    schema_map: &HashMap<String, TableSchemaEntry>,
+    resolver_schema: &MappingSchema,
+    strict: bool,
+    relationships: &[DeclaredRelationship],
+) -> Vec<ValidationError> {
+    let mut errors = Vec::new();
+    if let Some(select) = select_for_scope_expression(&scope.expression) {
+        let select_expr = Expression::Select(Box::new(select.clone()));
         let context = collect_type_check_context(&select_expr, schema_map);
-        let scope = build_scope(&select_expr);
-        let mut resolver = Resolver::new(&scope, resolver_schema, true);
+        let mut resolver = Resolver::new(scope, resolver_schema, true);
 
-        if context.referenced_tables.len() > 1 {
+        let direct_source_count = select
+            .from
+            .as_ref()
+            .map_or(0, |from| from.expressions.len())
+            + select.joins.len();
+        if direct_source_count > 1 {
             let using_columns: HashSet<String> = select
                 .joins
                 .iter()
@@ -2087,8 +2127,8 @@ fn check_query_reference_quality(
                 .collect();
 
             let mut seen = HashSet::new();
-            for column_expr in select_expr
-                .find_all(|e| matches!(e, Expression::Column(col) if col.table.is_none()))
+            for column_expr in walk_in_scope(&select_expr, false)
+                .filter(|e| matches!(e, Expression::Column(col) if col.table.is_none()))
             {
                 let Expression::Column(column) = column_expr else {
                     continue;
@@ -2192,6 +2232,51 @@ fn check_query_reference_quality(
         }
     }
 
+    for child in &scope.cte_scopes {
+        errors.extend(check_scope_reference_quality(
+            child,
+            schema_map,
+            resolver_schema,
+            strict,
+            relationships,
+        ));
+    }
+    for child in &scope.union_scopes {
+        errors.extend(check_scope_reference_quality(
+            child,
+            schema_map,
+            resolver_schema,
+            strict,
+            relationships,
+        ));
+    }
+    for child in &scope.derived_table_scopes {
+        errors.extend(check_scope_reference_quality(
+            child,
+            schema_map,
+            resolver_schema,
+            strict,
+            relationships,
+        ));
+    }
+    for child in &scope.udtf_scopes {
+        errors.extend(check_scope_reference_quality(
+            child,
+            schema_map,
+            resolver_schema,
+            strict,
+            relationships,
+        ));
+    }
+    for child in &scope.subquery_scopes {
+        errors.extend(check_scope_reference_quality(
+            child,
+            schema_map,
+            resolver_schema,
+            strict,
+            relationships,
+        ));
+    }
     errors
 }
 
@@ -3324,6 +3409,8 @@ fn source_display_name(scope: &crate::scope::Scope, source_name: &str) -> String
 
 fn validate_select_columns_with_schema(
     select: &crate::expressions::Select,
+    scope: &crate::scope::Scope,
+    outer_sources: &HashMap<String, crate::scope::SourceInfo>,
     schema_map: &HashMap<String, TableSchemaEntry>,
     resolver_schema: &MappingSchema,
     strict: bool,
@@ -3332,9 +3419,10 @@ fn validate_select_columns_with_schema(
     let mut normalized_select = select.clone();
     let _ = normalize_dotted_columns(&mut normalized_select, resolver_schema, true);
     let select_expr = Expression::Select(Box::new(normalized_select));
-    let scope = build_scope(&select_expr);
-    let mut resolver = Resolver::new(&scope, resolver_schema, true);
-    let source_names: Vec<String> = scope.sources.keys().cloned().collect();
+    let mut normalized_scope = scope.clone();
+    normalized_scope.expression = select_expr.clone();
+    let mut resolver = Resolver::new(&normalized_scope, resolver_schema, true);
+    let source_names: Vec<String> = normalized_scope.sources.keys().cloned().collect();
 
     for node in walk_in_scope(&select_expr, false) {
         let Expression::Column(column) = node else {
@@ -3347,7 +3435,8 @@ fn validate_select_columns_with_schema(
         }
 
         if let Some(table) = &column.table {
-            let Some(source_name) = resolve_scope_source_name(&scope, &table.name) else {
+            let Some(source_name) = resolve_scope_source_name(&normalized_scope, &table.name)
+            else {
                 // The table qualifier is not a declared alias or source in this scope
                 errors.push(if strict {
                     ValidationError::error(
@@ -3371,7 +3460,7 @@ fn validate_select_columns_with_schema(
 
             if let Ok(columns) = resolver.get_source_columns(&source_name) {
                 if !columns.is_empty() && !source_has_column(&columns, &col_name) {
-                    let table_name = source_display_name(&scope, &source_name);
+                    let table_name = source_display_name(&normalized_scope, &source_name);
                     errors.push(if strict {
                         ValidationError::error(
                             format!("Unknown column '{}' in table '{}'", col_name, table_name),
@@ -3403,6 +3492,45 @@ fn validate_select_columns_with_schema(
             continue;
         }
 
+        let mut outer_scope = normalized_scope.clone();
+        outer_scope.sources = outer_sources.clone();
+        let mut outer_resolver = Resolver::new(&outer_scope, resolver_schema, true);
+        let matching_outer_source_count = outer_scope
+            .sources
+            .keys()
+            .filter(|source_name| {
+                outer_resolver
+                    .get_source_columns(source_name)
+                    .ok()
+                    .is_some_and(|columns| {
+                        !columns.is_empty() && source_has_column(&columns, &col_name)
+                    })
+            })
+            .count();
+        if matching_outer_source_count == 1 {
+            continue;
+        }
+        if matching_outer_source_count > 1 {
+            errors.push(if strict {
+                ValidationError::error(
+                    format!(
+                        "Ambiguous unqualified column '{}' found in {} outer sources",
+                        col_name, matching_outer_source_count
+                    ),
+                    validation_codes::E_AMBIGUOUS_COLUMN_REFERENCE,
+                )
+            } else {
+                ValidationError::warning(
+                    format!(
+                        "Ambiguous unqualified column '{}' found in {} outer sources",
+                        col_name, matching_outer_source_count
+                    ),
+                    validation_codes::W_WEAK_REFERENCE_INTEGRITY,
+                )
+            });
+            continue;
+        }
+
         let known_sources: Vec<String> = source_names
             .iter()
             .filter_map(|source_name| {
@@ -3415,7 +3543,7 @@ fn validate_select_columns_with_schema(
             .collect();
 
         if known_sources.len() == 1 {
-            let table_name = source_display_name(&scope, &known_sources[0]);
+            let table_name = source_display_name(&normalized_scope, &known_sources[0]);
             errors.push(if strict {
                 ValidationError::error(
                     format!("Unknown column '{}' in table '{}'", col_name, table_name),
@@ -3468,6 +3596,120 @@ fn validate_select_columns_with_schema(
     errors
 }
 
+fn select_for_scope_expression(expression: &Expression) -> Option<&crate::expressions::Select> {
+    match expression {
+        Expression::Select(select) => Some(select),
+        Expression::Cte(cte) => select_for_scope_expression(&cte.this),
+        Expression::Subquery(subquery) => select_for_scope_expression(&subquery.this),
+        Expression::Alias(alias) => select_for_scope_expression(&alias.this),
+        Expression::Paren(paren) => select_for_scope_expression(&paren.this),
+        Expression::CreateTable(create) => create
+            .as_select
+            .as_ref()
+            .and_then(select_for_scope_expression),
+        Expression::Prepare(prepare) => select_for_scope_expression(&prepare.statement),
+        _ => None,
+    }
+}
+
+fn validate_scope_columns_with_schema(
+    scope: &crate::scope::Scope,
+    outer_sources: &HashMap<String, crate::scope::SourceInfo>,
+    schema_map: &HashMap<String, TableSchemaEntry>,
+    resolver_schema: &MappingSchema,
+    strict: bool,
+) -> Vec<ValidationError> {
+    let mut errors = Vec::new();
+    let empty_sources = HashMap::new();
+    let mut effective_scope = scope.clone();
+    if scope.can_be_correlated {
+        for node in walk_in_scope(&scope.expression, false) {
+            let Expression::Column(column) = node else {
+                continue;
+            };
+            let Some(table) = &column.table else {
+                continue;
+            };
+            if resolve_scope_source_name(&effective_scope, &table.name).is_some() {
+                continue;
+            }
+            if let Some((name, source)) = outer_sources
+                .iter()
+                .find(|(name, _)| name.eq_ignore_ascii_case(&table.name))
+            {
+                effective_scope.sources.insert(name.clone(), source.clone());
+            }
+        }
+    }
+
+    if let Some(select) = select_for_scope_expression(&scope.expression) {
+        errors.extend(validate_select_columns_with_schema(
+            select,
+            &effective_scope,
+            outer_sources,
+            schema_map,
+            resolver_schema,
+            strict,
+        ));
+    }
+
+    for child in &scope.cte_scopes {
+        errors.extend(validate_scope_columns_with_schema(
+            child,
+            &empty_sources,
+            schema_map,
+            resolver_schema,
+            strict,
+        ));
+    }
+    for child in &scope.union_scopes {
+        errors.extend(validate_scope_columns_with_schema(
+            child,
+            outer_sources,
+            schema_map,
+            resolver_schema,
+            strict,
+        ));
+    }
+    for child in &scope.derived_table_scopes {
+        errors.extend(validate_scope_columns_with_schema(
+            child,
+            if child.can_be_correlated {
+                outer_sources
+            } else {
+                &empty_sources
+            },
+            schema_map,
+            resolver_schema,
+            strict,
+        ));
+    }
+    for child in &scope.udtf_scopes {
+        errors.extend(validate_scope_columns_with_schema(
+            child,
+            if child.can_be_correlated {
+                outer_sources
+            } else {
+                &empty_sources
+            },
+            schema_map,
+            resolver_schema,
+            strict,
+        ));
+    }
+    for child in &scope.subquery_scopes {
+        errors.extend(validate_scope_columns_with_schema(
+            child,
+            &effective_scope.sources,
+            schema_map,
+            resolver_schema,
+            strict,
+        ));
+    }
+
+    errors
+}
+
 fn validate_statement_with_schema(
     stmt: &Expression,
     schema_map: &HashMap<String, TableSchemaEntry>,
@@ -3514,16 +3756,38 @@ fn validate_statement_with_schema(
         }
     }
 
-    for node in stmt.dfs() {
-        let Expression::Select(select) = node else {
-            continue;
-        };
-        errors.extend(validate_select_columns_with_schema(
-            select,
+    let scope = build_scope(stmt);
+    let has_scoped_query = select_for_scope_expression(&scope.expression).is_some()
+        || !scope.cte_scopes.is_empty()
+        || !scope.union_scopes.is_empty()
+        || !scope.derived_table_scopes.is_empty()
+        || !scope.udtf_scopes.is_empty()
+        || !scope.subquery_scopes.is_empty();
+    if has_scoped_query {
+        errors.extend(validate_scope_columns_with_schema(
+            &scope,
+            &HashMap::new(),
             schema_map,
             resolver_schema,
             strict,
         ));
+    } else {
+        // Preserve validation for query bodies in statement wrappers that the scope builder
+        // does not model yet, such as INSERT ... SELECT.
+        for node in stmt.dfs() {
+            let Expression::Select(select) = node else {
+                continue;
+            };
+            let select_expression = Expression::Select(select.clone());
+            let select_scope = build_scope(&select_expression);
+            errors.extend(validate_scope_columns_with_schema(
+                &select_scope,
+                &HashMap::new(),
+                schema_map,
+                resolver_schema,
+                strict,
+            ));
+        }
     }
 
     errors

--- a/crates/polyglot-sql/src/validation/tests.rs
+++ b/crates/polyglot-sql/src/validation/tests.rs
@@ -166,6 +166,18 @@ fn test_function_catalog() -> Arc<HashMapFunctionCatalog> {
     Arc::new(catalog)
 }
 
+fn schema_validation_dialects() -> [DialectType; 7] {
+    [
+        DialectType::Generic,
+        DialectType::Snowflake,
+        DialectType::DuckDB,
+        DialectType::BigQuery,
+        DialectType::Databricks,
+        DialectType::PostgreSQL,
+        DialectType::TSQL,
+    ]
+}
+
 #[test]
 fn test_validate_with_schema_known_table_column() {
     let schema = base_schema();
@@ -178,6 +190,401 @@ fn test_validate_with_schema_known_table_column() {
     );
     assert!(result.valid);
     assert!(result.errors.is_empty());
+}
+
+#[test]
+fn test_validate_with_schema_qualified_cte_column_is_not_ambiguous() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    for dialect in schema_validation_dialects() {
+        let result = validate_with_schema(
+            "WITH selected_users AS (SELECT id FROM users), \
+             selected_orders AS (SELECT id FROM orders) \
+             SELECT selected_users.id FROM selected_users \
+             JOIN selected_orders ON selected_users.id = selected_orders.id",
+            dialect,
+            &schema,
+            &opts,
+        );
+
+        assert!(result.valid, "{dialect}: {:#?}", result.errors);
+    }
+}
+
+#[test]
+fn test_validate_with_schema_correlated_subquery_resolves_outer_alias() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    for dialect in schema_validation_dialects() {
+        let result = validate_with_schema(
+            "SELECT outer_users.id FROM users outer_users \
+             WHERE EXISTS (SELECT 1 FROM orders inner_orders \
+             WHERE inner_orders.user_id = outer_users.id)",
+            dialect,
+            &schema,
+            &opts,
+        );
+
+        assert!(result.valid, "{dialect}: {:#?}", result.errors);
+    }
+}
+
+#[test]
+fn test_validate_with_schema_correlated_subquery_prefers_inner_unqualified_column() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    for dialect in schema_validation_dialects() {
+        let result = validate_with_schema(
+            "SELECT outer_users.id FROM users outer_users \
+             WHERE EXISTS (SELECT 1 FROM orders inner_orders \
+             WHERE id = outer_users.id)",
+            dialect,
+            &schema,
+            &opts,
+        );
+
+        assert!(result.valid, "{dialect}: {:#?}", result.errors);
+    }
+}
+
+#[test]
+fn test_validate_with_schema_subsequent_cte_resolves_prior_projection() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    for dialect in schema_validation_dialects() {
+        let result = validate_with_schema(
+            "WITH derived AS (SELECT total AS derived_total FROM orders), \
+             next AS (SELECT derived_total FROM derived) \
+             SELECT derived_total FROM next",
+            dialect,
+            &schema,
+            &opts,
+        );
+
+        assert!(result.valid, "{dialect}: {:#?}", result.errors);
+    }
+}
+
+#[test]
+fn test_validate_with_schema_window_resolves_prior_cte_projection() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    for dialect in schema_validation_dialects() {
+        let result = validate_with_schema(
+            "WITH scored AS (SELECT user_id, total AS order_total FROM orders), \
+             ranked AS (SELECT user_id, ROW_NUMBER() OVER ( \
+             PARTITION BY user_id ORDER BY order_total DESC) AS row_number FROM scored) \
+             SELECT user_id FROM ranked",
+            dialect,
+            &schema,
+            &opts,
+        );
+        assert!(result.valid, "{dialect}: {:#?}", result.errors);
+    }
+}
+
+#[test]
+fn test_validate_with_schema_joined_cte_projection_preserves_scope() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    for dialect in schema_validation_dialects() {
+        let result = validate_with_schema(
+            "WITH selected_users AS (SELECT id, name FROM users), \
+             selected_orders AS (SELECT id, user_id, total FROM orders), \
+             combined AS (SELECT selected_users.*, selected_orders.total \
+             FROM selected_users JOIN selected_orders \
+             ON selected_users.id = selected_orders.user_id) \
+             SELECT id, name, total FROM combined",
+            dialect,
+            &schema,
+            &opts,
+        );
+
+        assert!(result.valid, "{dialect}: {:#?}", result.errors);
+    }
+}
+
+#[test]
+fn test_validate_with_schema_chained_star_projection_preserves_aliases() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    for dialect in schema_validation_dialects() {
+        let result = validate_with_schema(
+            "WITH totals AS (SELECT user_id, total AS order_total FROM orders), \
+             copied AS (SELECT * FROM totals), \
+             scored AS (SELECT *, order_total + 1 AS adjusted_total FROM copied) \
+             SELECT user_id, order_total, adjusted_total FROM scored",
+            dialect,
+            &schema,
+            &opts,
+        );
+
+        assert!(result.valid, "{dialect}: {:#?}", result.errors);
+    }
+}
+
+#[test]
+fn test_validate_with_schema_snowflake_qualify_resolves_projection_columns() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    let result = validate_with_schema(
+        "WITH ranked AS (SELECT user_id, total, \
+         ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY total DESC) AS row_number \
+         FROM orders QUALIFY row_number = 1) \
+         SELECT user_id, total FROM ranked",
+        DialectType::Snowflake,
+        &schema,
+        &opts,
+    );
+    assert!(result.valid, "{:#?}", result.errors);
+}
+
+#[test]
+fn test_validate_with_schema_snowflake_union_by_name_preserves_projection() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    let result = validate_with_schema(
+        "WITH records AS (SELECT id, name FROM users \
+         UNION ALL BY NAME SELECT id, CAST(total AS VARCHAR) AS name FROM orders) \
+         SELECT id, name FROM records",
+        DialectType::Snowflake,
+        &schema,
+        &opts,
+    );
+    assert!(result.valid, "{:#?}", result.errors);
+}
+
+#[test]
+fn test_validate_with_schema_snowflake_join_using_resolves_cte_column() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    let result = validate_with_schema(
+        "WITH selected_users AS (SELECT id, name FROM users) \
+         SELECT orders.id, selected_users.name FROM orders \
+         INNER JOIN selected_users USING (id)",
+        DialectType::Snowflake,
+        &schema,
+        &opts,
+    );
+
+    assert!(result.valid, "{:#?}", result.errors);
+}
+
+#[test]
+fn test_validate_with_schema_snowflake_join_using_cte_from_same_table() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    let result = validate_with_schema(
+        "WITH selected_users AS (SELECT id FROM users WHERE age >= 18), \
+         combined AS (SELECT users.* FROM users \
+         INNER JOIN selected_users USING (id)) \
+         SELECT id, name FROM combined",
+        DialectType::Snowflake,
+        &schema,
+        &opts,
+    );
+
+    assert!(result.valid, "{:#?}", result.errors);
+}
+
+#[test]
+fn test_validate_with_schema_snowflake_nested_qualify_resolves_cte_projection() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    let result = validate_with_schema(
+        "WITH customer_orders AS (SELECT user_id, id AS order_id, total FROM orders), \
+         deduplicated AS (SELECT * FROM (SELECT user_id, order_id, total \
+         FROM customer_orders QUALIFY ROW_NUMBER() OVER (PARTITION BY user_id \
+         ORDER BY order_id) = 1)) SELECT user_id, order_id, total FROM deduplicated",
+        DialectType::Snowflake,
+        &schema,
+        &opts,
+    );
+
+    assert!(result.valid, "{:#?}", result.errors);
+}
+
+#[test]
+fn test_validate_with_schema_snowflake_deep_nested_qualify_resolves_cte_projection() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    let result = validate_with_schema(
+        "WITH base AS (SELECT id AS user_id, name, age FROM users), \
+         flags AS (SELECT user_id FROM (SELECT user_id FROM ( \
+         SELECT user_id, name, age FROM base \
+         QUALIFY ROW_NUMBER() OVER (PARTITION BY user_id, name ORDER BY age) = 1))) \
+         SELECT user_id FROM flags",
+        DialectType::Snowflake,
+        &schema,
+        &opts,
+    );
+
+    assert!(result.valid, "{:#?}", result.errors);
+}
+
+#[test]
+fn test_validate_with_schema_deep_star_chain_preserves_computed_alias() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    for dialect in schema_validation_dialects() {
+        let result = validate_with_schema(
+            "WITH base AS (SELECT user_id, total FROM orders), \
+             first_copy AS (SELECT *, total + 1 AS adjusted_total FROM base), \
+             second_copy AS (SELECT * FROM first_copy), \
+             third_copy AS (SELECT * FROM second_copy), \
+             fourth_copy AS (SELECT *, adjusted_total * 2 AS score FROM third_copy) \
+             SELECT user_id, adjusted_total, score FROM fourth_copy",
+            dialect,
+            &schema,
+            &opts,
+        );
+
+        assert!(result.valid, "{dialect}: {:#?}", result.errors);
+    }
+}
+
+#[test]
+fn test_validate_with_schema_nested_scalar_subquery_resolves_outer_column() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    for dialect in schema_validation_dialects() {
+        let result = validate_with_schema(
+            "WITH metrics AS (SELECT user_id, total AS score FROM orders), \
+             adjusted AS (SELECT score, CASE WHEN score IS NULL THEN NULL ELSE ( \
+             SELECT adjusted_score FROM (SELECT score + 1 AS adjusted_score)) END AS result \
+             FROM metrics) SELECT score, result FROM adjusted",
+            dialect,
+            &schema,
+            &opts,
+        );
+
+        assert!(result.valid, "{dialect}: {:#?}", result.errors);
+    }
+}
+
+#[test]
+fn test_validate_with_schema_ambiguous_outer_column_stays_invalid() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    let result = validate_with_schema(
+        "SELECT users.id FROM users JOIN orders ON users.id = orders.user_id \
+         WHERE EXISTS (SELECT 1 WHERE id > 0)",
+        DialectType::Generic,
+        &schema,
+        &opts,
+    );
+
+    assert!(!result.valid);
+    assert!(result.errors.iter().any(|error| {
+        error.code == validation_codes::E_AMBIGUOUS_COLUMN_REFERENCE
+            && error.message.contains("outer sources")
+    }));
+}
+
+#[test]
+fn test_validate_with_schema_unknown_column_after_cte_projection_stays_invalid() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions {
+        check_references: true,
+        ..Default::default()
+    };
+    let result = validate_with_schema(
+        "WITH selected_users AS (SELECT id, name FROM users) \
+         SELECT missing_column FROM selected_users",
+        DialectType::Generic,
+        &schema,
+        &opts,
+    );
+
+    assert!(!result.valid);
+    assert!(result
+        .errors
+        .iter()
+        .any(|error| error.code == validation_codes::E_UNKNOWN_COLUMN));
+}
+
+#[test]
+fn test_validate_with_schema_unknown_column_in_derived_table() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions::default();
+    let result = validate_with_schema(
+        "SELECT selected.id FROM (SELECT missing FROM users) selected",
+        DialectType::Generic,
+        &schema,
+        &opts,
+    );
+
+    assert!(!result.valid);
+    assert!(result
+        .errors
+        .iter()
+        .any(|error| error.code == validation_codes::E_UNKNOWN_COLUMN));
+}
+
+#[test]
+fn test_validate_with_schema_unknown_column_in_insert_query() {
+    let schema = base_schema();
+    let opts = SchemaValidationOptions::default();
+    let result = validate_with_schema(
+        "INSERT INTO users (id) SELECT missing FROM orders",
+        DialectType::Generic,
+        &schema,
+        &opts,
+    );
+
+    assert!(!result.valid);
+    assert!(result
+        .errors
+        .iter()
+        .any(|error| error.code == validation_codes::E_UNKNOWN_COLUMN));
 }
 
 #[test]


### PR DESCRIPTION
## Why

Schema-aware reference checks rebuilt nested `SELECT` scopes independently. This could report valid CTE projections as ambiguous and lose unqualified outer references inside nested scalar subqueries.

## Changes

- Traverse the scope tree already produced for the complete statement.
- Validate ambiguity within each query's direct sources.
- Preserve correlated outer-column fallback through nested derived scopes.
- Keep genuinely unknown and ambiguous columns invalid.
- Add neutral CTE, star projection, `QUALIFY`, `JOIN USING`, set-operation, and negative coverage across supported dialects.

## Verification

- `cargo fmt --check`
- `cargo test -p polyglot-sql validation::tests -- --nocapture` (62 passed)
- Public tree and reachable-history hygiene scan passed.

This clean contribution replaces #443, whose branch later acquired fork-specific packaging commits.
